### PR TITLE
Chore/106 156 ocultar menu integracao

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "engines": {
-    "node": "22.15.1",
-    "yarn": "1.22.4"
+    "node": "22.13.1",
+    "yarn": "1.22.22"
   },
   "name": "sol.api",
   "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "engines": {
-    "node": "22.13.1",
-    "yarn": "1.22.22"
+    "node": "22.15.1",
+    "yarn": "1.22.4"
   },
   "name": "sol.api",
   "version": "0.0.1",

--- a/src/modules/SOL/services/endpoints.service.ts
+++ b/src/modules/SOL/services/endpoints.service.ts
@@ -169,7 +169,9 @@ export class EndPointsService {
     }
     */
     // Registrando mensagem de desativação no log
-    this._logger.warn("Funcionalidade de Integração temporariamente desativada");
+    this._logger.warn(
+      "Funcionalidade de Integração temporariamente desativada",
+    );
     // Não retornamos nada para manter a compatibilidade com o tipo Promise<void>
     return;
   }
@@ -180,9 +182,11 @@ export class EndPointsService {
     // Pode ser reativada no futuro removendo os comentários abaixo.
     const endpoints = await this.endpointsRepository.list();
     if (endpoints.length > 0) {
-      this._logger.warn("Integração está desativada. Os jobs não serão inicializados.");
+      this._logger.warn(
+        "Integração está desativada. Os jobs não serão inicializados.",
+      );
     }
-    
+
     // Comentando a inicialização dos jobs
     /*
     endpoints.forEach((endpoint) => {

--- a/src/modules/SOL/services/endpoints.service.ts
+++ b/src/modules/SOL/services/endpoints.service.ts
@@ -28,6 +28,8 @@ export class EndPointsService {
   }
 
   async createEndpoint(endpoint: EndPointsInterface): Promise<EndPointsModel> {
+    // FUNCIONALIDADE DESATIVADA: A funcionalidade de Integração foi temporariamente desativada por decisão da equipe.
+    // Pode ser reativada no futuro removendo os comentários abaixo.
     const old = await this.endpointsRepository.getByEndpointType(
       endpoint.endpointType,
     );
@@ -43,7 +45,8 @@ export class EndPointsService {
       this._logger.debug(
         `Running endpoint${endpoint.endpointType} :${endpoint.endpointPath}`,
       );
-      return this.dynamicJob(endpoint.endpointType);
+      // Chamando o método e ignorando o retorno para garantir compatibilidade com Promise<void>
+      await this.dynamicJob(endpoint.endpointType);
     });
 
     this.schedulerRegistry.addCronJob(endpoint.endpointType, job);
@@ -53,7 +56,22 @@ export class EndPointsService {
   }
 
   async listEndpoints(): Promise<EndPointsModel[]> {
-    return await this.endpointsRepository.list();
+    // FUNCIONALIDADE DESATIVADA: A funcionalidade de Integração foi temporariamente desativada por decisão da equipe.
+    // Pode ser reativada no futuro removendo os comentários abaixo.
+    /*
+    try {
+      return await this.endpointsRepository.list();
+    } catch (error) {
+      throw new BadRequestException(
+        {
+          message: "Erro ao listar endpoints",
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    */
+    // Retornando lista vazia para evitar erros no frontend
+    return [];
   }
 
   async getEndpointById(_id: string): Promise<EndPointsModel> {
@@ -64,6 +82,8 @@ export class EndPointsService {
     _id: string,
     endpoint: EndPointsInterface,
   ): Promise<EndPointsModel> {
+    // FUNCIONALIDADE DESATIVADA: A funcionalidade de Integração foi temporariamente desativada por decisão da equipe.
+    // Pode ser reativada no futuro removendo os comentários abaixo.
     endpoint.status = EndPointsStatusEnum.stopped;
     const result = await this.endpointsRepository.update(_id, endpoint);
     if (!result) {
@@ -78,7 +98,8 @@ export class EndPointsService {
       this._logger.debug(
         `Running endpoint ${endpoint.endpointType} :${endpoint.endpointPath}`,
       );
-      return this.dynamicJob(endpoint.endpointType);
+      // Chamando o método e ignorando o retorno para garantir compatibilidade com Promise<void>
+      await this.dynamicJob(endpoint.endpointType);
     });
 
     this.schedulerRegistry.addCronJob(result.endpointType, job);
@@ -98,57 +119,84 @@ export class EndPointsService {
     return await this.endpointsRepository.deleteById(_id);
   }
 
-  async dynamicJob(type: EndPointsTypeEnum) {
-    const endpoint = await this.endpointsRepository.getByEndpointType(type);
-    endpoint.lastRun = new Date();
-    endpoint.status = EndPointsStatusEnum.running;
-    await this.endpointsRepository.update(endpoint.id, endpoint);
+  async dynamicJob(type: EndPointsTypeEnum): Promise<void> {
+    // FUNCIONALIDADE DESATIVADA: A funcionalidade de Integração foi temporariamente desativada por decisão da equipe.
+    // Pode ser reativada no futuro removendo os comentários abaixo.
+    /*
     try {
-      const headers = {
-        Authorization: endpoint.token,
-      };
+      const endpoint = await this.endpointsRepository.getByEndpointType(type);
+      endpoint.lastRun = new Date();
+      endpoint.status = EndPointsStatusEnum.running;
+      await this.endpointsRepository.update(endpoint.id, endpoint);
+      try {
+        const headers = {
+          Authorization: endpoint.token,
+        };
 
-      const result = await firstValueFrom(
-        this.httpService.get(endpoint.endpointPath, { headers }),
-      );
+        const result = await firstValueFrom(
+          this.httpService.get(endpoint.endpointPath, { headers }),
+        );
 
-      if (result.data) {
-        endpoint.status = EndPointsStatusEnum.success;
+        if (result.data) {
+          endpoint.status = EndPointsStatusEnum.success;
+          await this.endpointsRepository.update(endpoint.id, endpoint);
+          if (type === EndPointsTypeEnum.association)
+            return await this.associationService.handlerJob(result.data);
+          if (type === EndPointsTypeEnum.agreement)
+            return await this.agreementService.handlerJob(result.data);
+          if (type === EndPointsTypeEnum.costItems)
+            return await this.costItemsService.handlerJob(result.data);
+        }
+
+        endpoint.status = EndPointsStatusEnum.error;
+        endpoint.messageError = "Não foi possivel obter os dados do endpoint";
+
         await this.endpointsRepository.update(endpoint.id, endpoint);
-        if (type === EndPointsTypeEnum.association)
-          return await this.associationService.handlerJob(result.data);
-        if (type === EndPointsTypeEnum.agreement)
-          return await this.agreementService.handlerJob(result.data);
-        if (type === EndPointsTypeEnum.costItems)
-          return await this.costItemsService.handlerJob(result.data);
+        return;
+      } catch (error) {
+        endpoint.status = EndPointsStatusEnum.error;
+        endpoint.messageError = error;
+        this._logger.error(error);
+        await this.endpointsRepository.update(endpoint.id, endpoint);
       }
-
-      endpoint.status = EndPointsStatusEnum.error;
-      endpoint.messageError = "Não foi possivel obter os dados do endpoint";
-
-      await this.endpointsRepository.update(endpoint.id, endpoint);
-      return;
     } catch (error) {
-      endpoint.status = EndPointsStatusEnum.error;
-      endpoint.messageError = error;
-      this._logger.error(error);
-      await this.endpointsRepository.update(endpoint.id, endpoint);
+      throw new BadRequestException(
+        {
+          message: "Erro ao executar job",
+        },
+        HttpStatus.BAD_REQUEST,
+      );
     }
+    */
+    // Registrando mensagem de desativação no log
+    this._logger.warn("Funcionalidade de Integração temporariamente desativada");
+    // Não retornamos nada para manter a compatibilidade com o tipo Promise<void>
+    return;
   }
 
   async initAllJobs() {
     this._logger.debug("EndpointsService initialized");
+    // FUNCIONALIDADE DESATIVADA: A funcionalidade de Integração foi temporariamente desativada por decisão da equipe.
+    // Pode ser reativada no futuro removendo os comentários abaixo.
     const endpoints = await this.endpointsRepository.list();
+    if (endpoints.length > 0) {
+      this._logger.warn("Integração está desativada. Os jobs não serão inicializados.");
+    }
+    
+    // Comentando a inicialização dos jobs
+    /*
     endpoints.forEach((endpoint) => {
       const job = new CronJob(endpoint.frequency, async () => {
         this._logger.debug(
           `Running endpoint ${endpoint.endpointType} :${endpoint.endpointPath}`,
         );
-        return this.dynamicJob(endpoint.endpointType);
+        // Chamando o método e ignorando o retorno para garantir compatibilidade com Promise<void>
+        await this.dynamicJob(endpoint.endpointType);
       });
 
       this.schedulerRegistry.addCronJob(endpoint.endpointType, job);
       this.schedulerRegistry.getCronJob(endpoint.endpointType).start();
     });
+    */
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,15 +2132,6 @@ class-validator@^0.14.1:
     libphonenumber-js "^1.10.53"
     validator "^13.9.0"
 
-class-validator@^0.14.1:
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/class-validator/-/class-validator-0.14.1.tgz#ff2411ed8134e9d76acfeb14872884448be98110"
-  integrity sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==
-  dependencies:
-    "@types/validator" "^13.11.8"
-    libphonenumber-js "^1.10.53"
-    validator "^13.9.0"
-
 cli-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
@@ -5592,16 +5583,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5633,14 +5615,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6147,7 +6122,7 @@ validator@^13.9.0:
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.15.0.tgz#2dc7ce057e7513a55585109eec29b2c8e8c1aefd"
   integrity sha512-36B2ryl4+oL5QxZ3AzD0t5SsMNGvTtQHpjgFO5tbNxfXbMFkY822ktCDe1MnlqV3301QQI9SLHDNJokDI+Z9pA==
 
-vary@^1, vary@~1.1.2:
+vary@^1, vary@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
@@ -6279,7 +6254,7 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -6292,15 +6267,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Desativar serviços e handlers da Integração

### O que foi feito

- Comentados métodos relacionados à Integração em `endpoints.service.ts`.
- Ajustados tipos de retorno e adicionados logs de advertência.
- Bloqueada inicialização de jobs relacionados à Integração.
- Corrigidos erros de TypeScript em callbacks e retornos de métodos desativados.
- Funcionalidade temporariamente desativada por decisão do **CTO**.