### PR TITLE
Make dependabot act on staging

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    target-branch: "staging"


### PR DESCRIPTION
We should avoid hotfixing main and aim at merging only perfectly working code.