### PR TITLE
fix(219): corrigir falha na aceitação de propostas

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Backend do SOL: Solução Online de Licitação.
 
 ## Dependencies
 
-[![NodeJS](https://img.shields.io/badge/node.js-%2343853D.svg?style=for-the-badge&logo=node.js&logoColor=white)]((https://nodejs.org/en//))
+[![NodeJS](https://img.shields.io/badge/node.js-%2343853D.svg?style=for-the-badge&logo=node.js&logoColor=white)](<(https://nodejs.org/en//)>)
 [![YARN](https://img.shields.io/badge/Yarn-2C8EBB.svg?style=for-the-badge&logo=Yarn&logoColor=white)](https://yarnpkg.com/cli/install)
 [![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white)](https://docs.docker.com/compose/install/#install-compose)
 
@@ -25,6 +25,12 @@ To build the docker image with the project running inside, use:
 ```sh
 docker build .
 ```
+
+## Errors Handler
+
+1. Criar o identificador do erro(enum) em shared/enums/errors.ts
+2. Utilizar da seguinte forma:
+   `throw new CustomExceptionV2(BackendErrors.PROPOSAL_NOT_FOUND, {proposal_id: 1})`
 
 ## Running
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "engines": {
-    "node": "22.15.1",
-    "yarn": "1.22.4"
+    "node": "22.13.1",
+    "yarn": "1.22.22"
   },
   "name": "sol.api",
   "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "engines": {
-    "node": "22.13.1",
-    "yarn": "1.22.22"
+    "node": "22.15.1",
+    "yarn": "1.22.4"
   },
   "name": "sol.api",
   "version": "0.0.1",

--- a/src/modules/SOL/controllers/allotment.controller.ts
+++ b/src/modules/SOL/controllers/allotment.controller.ts
@@ -22,6 +22,7 @@ import { AllotUpdateStatusRequestDto } from "../dtos/allotment-update-status-req
 import { FuncoesGuard } from "src/shared/guards/funcoes.guard";
 import { Funcoes } from "src/shared/decorators/function.decorator";
 import { UserTypeEnum } from "../enums/user-type.enum";
+import { StructuredErrorHelper } from "../../../shared/helpers/structured-error.helper";
 
 @ApiTags("allotment")
 @Controller("allotment")
@@ -40,11 +41,13 @@ export class AllotmentController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -58,11 +61,13 @@ export class AllotmentController {
       const response = await this.allotmentService.listById(_id);
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -78,11 +83,13 @@ export class AllotmentController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -103,11 +110,13 @@ export class AllotmentController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -121,11 +130,13 @@ export class AllotmentController {
       const response = await this.allotmentService.downloadAllotmentById(_id);
       return response;
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }

--- a/src/modules/SOL/controllers/bid.controller.ts
+++ b/src/modules/SOL/controllers/bid.controller.ts
@@ -93,7 +93,9 @@ export class BidController {
       if (error.isStructuredError) {
         throw error;
       }
-      this.logger.error(`Erro inesperado ao registrar licitação: ${error.message}`);
+      this.logger.error(
+        `Erro inesperado ao registrar licitação: ${error.message}`,
+      );
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
         HttpStatus.INTERNAL_SERVER_ERROR,

--- a/src/modules/SOL/controllers/bid.controller.ts
+++ b/src/modules/SOL/controllers/bid.controller.ts
@@ -36,6 +36,7 @@ import { BidDateUpdateDto } from "../dtos/bid-date-update.dto";
 import { LacchainModel } from "../models/blockchain/lacchain.model";
 import { BidHistoryModel } from "../models/database/bid_history.model";
 import { ErrorManager } from "../../../shared/utils/error.manager";
+import { StructuredErrorHelper } from "../../../shared/helpers/structured-error.helper";
 import { BidStatusEnum } from "../enums/bid-status.enum";
 import { BidTypeEnum } from "../enums/bid-type.enum";
 import { BidModalityEnum } from "../enums/bid-modality.enum";
@@ -89,20 +90,13 @@ export class BidController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      // Log detalhado do erro para facilitar a depuração
-      this.logger.error(`Erro ao registrar licitação: ${error.message}`);
-
-      // Melhorar a mensagem de erro para o frontend
-      const errorMessage =
-        error.message || "Erro interno ao processar a licitação";
-      const statusCode =
-        error instanceof BadRequestException
-          ? HttpStatus.BAD_REQUEST
-          : HttpStatus.INTERNAL_SERVER_ERROR;
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado ao registrar licitação: ${error.message}`);
       throw new HttpException(
-        new ResponseDto(false, null, [errorMessage]),
-        statusCode,
+        new ResponseDto(false, null, [error.message]),
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -117,11 +111,13 @@ export class BidController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -138,11 +134,13 @@ export class BidController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -161,11 +159,13 @@ export class BidController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -206,11 +206,13 @@ export class BidController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -227,11 +229,13 @@ export class BidController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -247,11 +251,13 @@ export class BidController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -267,11 +273,13 @@ export class BidController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -288,11 +296,13 @@ export class BidController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -309,11 +319,13 @@ export class BidController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -328,11 +340,13 @@ export class BidController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -350,11 +364,13 @@ export class BidController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -386,11 +402,13 @@ export class BidController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -406,11 +424,13 @@ export class BidController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }

--- a/src/modules/SOL/controllers/proposal.controller.ts
+++ b/src/modules/SOL/controllers/proposal.controller.ts
@@ -302,6 +302,11 @@ export class ProposalController {
     } catch (error) {
       this.logger.error(error.message);
 
+      // Verifica se é um erro estruturado e preserva sua estrutura
+      if (error instanceof HttpException && (error as any).isStructuredError) {
+        throw error; // Re-lança o erro estruturado sem modificar
+      }
+
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
         HttpStatus.BAD_REQUEST,

--- a/src/modules/SOL/controllers/proposal.controller.ts
+++ b/src/modules/SOL/controllers/proposal.controller.ts
@@ -445,8 +445,6 @@ export class ProposalController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
         HttpStatus.BAD_REQUEST,

--- a/src/modules/SOL/controllers/user.controller.ts
+++ b/src/modules/SOL/controllers/user.controller.ts
@@ -42,6 +42,7 @@ import { UserUpdateValidator } from "../validators/user-update.validator";
 import { UserUpdateByIdRequestDto } from "../dtos/user-update-by-id-request.dto";
 import { UserRolesEnum } from "../enums/user-roles.enum";
 import { VerificationRegisterResponseDto } from "../dtos/vertification-register-response.dto";
+import { StructuredErrorHelper } from "../../../shared/helpers/structured-error.helper";
 
 @ApiTags("user")
 @Controller("user")
@@ -66,11 +67,13 @@ export class UserController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -85,11 +88,13 @@ export class UserController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -104,11 +109,13 @@ export class UserController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -123,11 +130,13 @@ export class UserController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -143,11 +152,13 @@ export class UserController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -163,11 +174,13 @@ export class UserController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -183,11 +196,13 @@ export class UserController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -201,11 +216,13 @@ export class UserController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -222,11 +239,13 @@ export class UserController {
 
       return new ResponseDto(true, true, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -241,11 +260,13 @@ export class UserController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -262,11 +283,13 @@ export class UserController {
         return new ResponseDto(true, response, null);
       }
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -282,11 +305,13 @@ export class UserController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -302,11 +327,13 @@ export class UserController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -325,11 +352,13 @@ export class UserController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -353,11 +382,13 @@ export class UserController {
 
       return new ResponseDto(true, response, null);
     } catch (error) {
-      this.logger.error(error.message);
-
+      if (error.isStructuredError) {
+        throw error;
+      }
+      this.logger.error(`Erro inesperado: ${error.message}`);
       throw new HttpException(
         new ResponseDto(false, null, [error.message]),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }

--- a/src/modules/SOL/repositories/proposal.repository.ts
+++ b/src/modules/SOL/repositories/proposal.repository.ts
@@ -221,6 +221,7 @@ export class ProposalRepository {
       .populate("acceptedFornecedor")
       .populate("acceptedRevisor")
       .populate("allotment")
+      .populate("bid")
       .sort({ total_value: "descending" });
     // const sortedProposals = proposals.sort((a, b) => Number(a.total_value) - Number(b.total_value));
     return proposals;
@@ -254,7 +255,8 @@ export class ProposalRepository {
       .populate("refusedBy")
       .populate("acceptedFornecedor")
       .populate("acceptedRevisor")
-      .populate("allotment");
+      .populate("allotment")
+      .populate("bid");
     if (proposals.length > 1) {
       const sortedProposals = proposals.sort(
         (a, b) => Number(a.total_value) - Number(b.total_value),
@@ -275,7 +277,7 @@ export class ProposalRepository {
   }
 
   async getProposalWin(bidId: string): Promise<ProposalModel> {
-    const list = await this._model.find({ bid: { _id: bidId } });
+    const list = await this._model.find({ bid: { _id: bidId } }).populate("bid");
     const sortedProposals = list
       .sort((a, b) => Number(a.total_value) - Number(b.total_value))
       .filter(
@@ -293,7 +295,8 @@ export class ProposalRepository {
       .populate("refusedBy")
       .populate("acceptedFornecedor")
       .populate("acceptedRevisor")
-      .populate("allotment");
+      .populate("allotment")
+      .populate("bid");
   }
 
   async getById(_id: string): Promise<ProposalModel> {
@@ -303,7 +306,8 @@ export class ProposalRepository {
       .populate("refusedBy")
       .populate("acceptedFornecedor")
       .populate("acceptedRevisor")
-      .populate("allotment");
+      .populate("allotment")
+      .populate("bid");
   }
 
   async deleteById(_id: string) {

--- a/src/modules/SOL/repositories/proposal.repository.ts
+++ b/src/modules/SOL/repositories/proposal.repository.ts
@@ -277,7 +277,9 @@ export class ProposalRepository {
   }
 
   async getProposalWin(bidId: string): Promise<ProposalModel> {
-    const list = await this._model.find({ bid: { _id: bidId } }).populate("bid");
+    const list = await this._model
+      .find({ bid: { _id: bidId } })
+      .populate("bid");
     const sortedProposals = list
       .sort((a, b) => Number(a.total_value) - Number(b.total_value))
       .filter(

--- a/src/modules/SOL/services/bid.service.ts
+++ b/src/modules/SOL/services/bid.service.ts
@@ -46,6 +46,8 @@ import { BidHistoryModel } from "../models/database/bid_history.model";
 import { ItemsModel } from "../models/database/items.model";
 import { SHA256, enc } from "crypto-js";
 import { bidStatusTranslations } from "src/shared/utils/translation.utils";
+import { StructuredErrorHelper } from "../../../shared/helpers/structured-error.helper";
+import { BackendErrors } from "../../../shared/enums/errors";
 
 const PizZip = require("pizzip");
 const Docxtemplater = require("docxtemplater");
@@ -193,9 +195,9 @@ export class BidService {
     const association = await this._userRepository.getById(associationId);
     const agreement = await this._agreementService.findById(dto.agreementId);
 
-    if (!agreement) throw new BadRequestException("Convênio não encontrado!");
+    if (!agreement) StructuredErrorHelper.throwAgreementNotFound(dto.agreementId);
     if (!association)
-      throw new BadRequestException("Associação nao encontrada!");
+      StructuredErrorHelper.throwAssociationNotFound(associationId);
     dto.agreement = agreement;
     dto.association = association;
 
@@ -303,9 +305,7 @@ export class BidService {
         dto.add_allotment = [];
       } else {
         // Para licitações finais, exigir lotes
-        throw new BadRequestException(
-          "Não foi possível cadastrar essa licitação! É necessário adicionar pelo menos um lote.",
-        );
+        StructuredErrorHelper.throw(BackendErrors.BID_MISSING_ALLOTMENTS);
       }
     } catch (error) {
       // Se for rascunho, ignorar erros relacionados aos lotes
@@ -324,9 +324,7 @@ export class BidService {
     try {
       const result = await this._bidsRepository.register(dto);
       if (!result) {
-        throw new BadRequestException(
-          "Não foi possivel cadastrar essa licitação!",
-        );
+        StructuredErrorHelper.throw(BackendErrors.BID_REGISTRATION_FAILED);
       }
 
       // Lacchain
@@ -411,9 +409,7 @@ export class BidService {
       return result;
     } catch (error) {
       this._logger.error(`Erro ao registrar licitação: ${error.message}`);
-      throw new BadRequestException(
-        `Não foi possivel cadastrar essa licitação: ${error.message}`,
-      );
+      StructuredErrorHelper.throw(BackendErrors.BID_REGISTRATION_FAILED);
     }
   }
 
@@ -539,11 +535,11 @@ export class BidService {
   async update(_id: string, dto: BidUpdateDto): Promise<BidModel> {
     const item = await this._bidsRepository.getById(_id);
     if (!item) {
-      throw new BadRequestException("Não foi possivel atualizar a licitação!");
+      StructuredErrorHelper.throwBidNotFound(_id);
     }
 
     const agreement = await this._agreementService.findById(dto.agreementId);
-    if (!agreement) throw new BadRequestException("Convênio não encontrado!");
+    if (!agreement) StructuredErrorHelper.throwAgreementNotFound(dto.agreementId);
     dto.agreement = agreement;
 
     let newArray = [];
@@ -585,9 +581,7 @@ export class BidService {
   async addProposal(_id: string, dto: BidAddProposalDto): Promise<BidModel> {
     const item = await this._bidsRepository.getById(_id);
     if (!item) {
-      throw new BadRequestException(
-        "Não foi possivel atualizar a adicionar proposta na licitação!",
-      );
+      StructuredErrorHelper.throwBidNotFound(_id);
     }
     const result = await this._bidsRepository.addProposal(_id, dto);
     return result;
@@ -601,7 +595,7 @@ export class BidService {
   ): Promise<BidModel | any> {
     const user = await this._userRepository.getById(userId);
 
-    if (!user) throw new BadRequestException("Usuário não encontrado!");
+    if (!user) StructuredErrorHelper.throwUserNotFound(userId);
 
     if (user.type === "administrador") dto.proofreader = user;
 
@@ -614,9 +608,7 @@ export class BidService {
       const configs = await this._plataformRepository.findOne();
 
       if (!configs)
-        throw new BadRequestException(
-          "Não foi possivel encontrar as configurações da plataforma!",
-        );
+        StructuredErrorHelper.throw(BackendErrors.PLATFORM_CONFIG_NOT_FOUND);
 
       const { start_at } = await this._bidsRepository.addStartHour(
         _id,

--- a/src/modules/SOL/services/bid.service.ts
+++ b/src/modules/SOL/services/bid.service.ts
@@ -195,7 +195,8 @@ export class BidService {
     const association = await this._userRepository.getById(associationId);
     const agreement = await this._agreementService.findById(dto.agreementId);
 
-    if (!agreement) StructuredErrorHelper.throwAgreementNotFound(dto.agreementId);
+    if (!agreement)
+      StructuredErrorHelper.throwAgreementNotFound(dto.agreementId);
     if (!association)
       StructuredErrorHelper.throwAssociationNotFound(associationId);
     dto.agreement = agreement;
@@ -539,7 +540,8 @@ export class BidService {
     }
 
     const agreement = await this._agreementService.findById(dto.agreementId);
-    if (!agreement) StructuredErrorHelper.throwAgreementNotFound(dto.agreementId);
+    if (!agreement)
+      StructuredErrorHelper.throwAgreementNotFound(dto.agreementId);
     dto.agreement = agreement;
 
     let newArray = [];

--- a/src/modules/SOL/services/proposal.service.ts
+++ b/src/modules/SOL/services/proposal.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable, Logger } from "@nestjs/common";
+import { StructuredErrorHelper } from "../../../shared/helpers/structured-error.helper";
 import { ProposalModel } from "../models/proposal.model";
 import { ProposalRegisterDto } from "../dtos/proposal-register-request.dto";
 import { ProposalRepository } from "../repositories/proposal.repository";
@@ -393,7 +394,7 @@ export class ProposalService {
   ): Promise<ProposalModel> {
     const item = await this._proposalRepository.getById(_id);
     if (!item) {
-      throw new BadRequestException(ProposalErrorMessages.PROPOSAL_NOT_FOUND);
+      StructuredErrorHelper.throwProposalNotFound(_id);
     }
 
     const result = await this._proposalRepository.updateAcceptSupplier(
@@ -415,7 +416,7 @@ export class ProposalService {
   ): Promise<ProposalModel> {
     const item = await this._proposalRepository.getById(_id);
     if (!item) {
-      throw new BadRequestException(ProposalErrorMessages.PROPOSAL_NOT_FOUND);
+      StructuredErrorHelper.throwProposalNotFound(_id);
     }
 
     const result = await this._proposalRepository.updateAcceptAssociation(
@@ -439,7 +440,7 @@ export class ProposalService {
   ): Promise<ProposalModel | any> {
     const item = await this._proposalRepository.getById(_id);
     if (!item) {
-      throw new BadRequestException(ProposalErrorMessages.PROPOSAL_NOT_FOUND);
+      StructuredErrorHelper.throwProposalNotFound(_id);
     }
     const result = await this._proposalRepository.updateAcceptReviewer(
       _id,
@@ -542,8 +543,11 @@ export class ProposalService {
       );
 
       if (hasAllotmentInAnalysis) {
-        throw new BadRequestException(
-          ProposalErrorMessages.CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS,
+        const allotmentInAnalysis = proposal.allotment?.find(
+          (a) => a.status === AllotmentStatusEnum.emAnalise,
+        );
+        StructuredErrorHelper.throwCannotAcceptAllotmentInAnalysis(
+          allotmentInAnalysis?._id?.toString() || 'unknown'
         );
       }
       const dto = {
@@ -594,8 +598,11 @@ export class ProposalService {
       );
 
       if (hasAllotmentInAnalysis) {
-        throw new BadRequestException(
-          ProposalErrorMessages.CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS,
+        const allotmentInAnalysis = proposal.allotment?.find(
+          (a) => a.status === AllotmentStatusEnum.emAnalise,
+        );
+        StructuredErrorHelper.throwCannotAcceptAllotmentInAnalysis(
+          allotmentInAnalysis?._id?.toString() || 'unknown'
         );
       }
 
@@ -657,7 +664,7 @@ export class ProposalService {
   ): Promise<ProposalModel> {
     const item = await this._proposalRepository.getById(_id);
     if (!item) {
-      throw new BadRequestException(ProposalErrorMessages.PROPOSAL_NOT_FOUND);
+      StructuredErrorHelper.throwProposalNotFound(_id);
     }
 
     const result = await this._proposalRepository.updateStatus(_id, dto);
@@ -693,7 +700,7 @@ export class ProposalService {
   ): Promise<ProposalModel> {
     const item = await this._proposalRepository.getById(_id);
     if (!item) {
-      throw new BadRequestException(ProposalErrorMessages.PROPOSAL_NOT_FOUND);
+      StructuredErrorHelper.throwProposalNotFound(_id);
     }
     const result = await this._proposalRepository.addItem(_id, dto);
     return result;
@@ -705,7 +712,7 @@ export class ProposalService {
   ): Promise<ProposalModel> {
     const item = await this._proposalRepository.getById(_id);
     if (!item) {
-      throw new BadRequestException(ProposalErrorMessages.PROPOSAL_NOT_FOUND);
+      StructuredErrorHelper.throwProposalNotFound(_id);
     }
     const result = await this._proposalRepository.removeItem(_id, dto);
     return result;
@@ -715,12 +722,10 @@ export class ProposalService {
     const result = await this._proposalRepository.getById(_id);
 
     if (!result) {
-      throw new BadRequestException(ProposalErrorMessages.PROPOSAL_NOT_FOUND);
+      StructuredErrorHelper.throwProposalNotFound(_id);
     }
     if (result.deleted === true) {
-      throw new BadRequestException(
-        ProposalErrorMessages.PROPOSAL_ALREADY_DELETED,
-      );
+      StructuredErrorHelper.throwProposalAlreadyDeleted(_id);
     }
     return result;
   }

--- a/src/modules/SOL/services/proposal.service.ts
+++ b/src/modules/SOL/services/proposal.service.ts
@@ -34,7 +34,10 @@ import { AllotmentModel } from "../models/allotment.model";
 import { BidService } from "./bid.service";
 import { ProposalReviewerAcceptUpdateDto } from "../dtos/proposal-accept-reviewer-update.dto";
 import { extractAndCompareContent } from "../utils/string-and-id-compare.helper";
-import { extractBidId, extractSupplierId } from "../utils/entity-id-extractor.helper";
+import {
+  extractBidId,
+  extractSupplierId,
+} from "../utils/entity-id-extractor.helper";
 import { ProposalErrorMessages } from "../utils/error-messages.helper";
 import { Proposal } from "../schemas/proposal.schema";
 
@@ -75,9 +78,7 @@ export class ProposalService {
       BidStatusEnum.open !== bid.status &&
       BidStatusEnum.reopened !== bid.status
     )
-      throw new BadRequestException(
-        ProposalErrorMessages.BID_CLOSED,
-      );
+      throw new BadRequestException(ProposalErrorMessages.BID_CLOSED);
 
     dto.bid = bid;
 
@@ -116,9 +117,7 @@ export class ProposalService {
         ),
       );
       if (verify) {
-        throw new BadRequestException(
-          ProposalErrorMessages.DUPLICATE_PROPOSAL,
-        );
+        throw new BadRequestException(ProposalErrorMessages.DUPLICATE_PROPOSAL);
       }
     }
 
@@ -332,9 +331,7 @@ export class ProposalService {
 
     const result = await this._proposalRepository.register(dto);
     if (!result)
-      throw new BadRequestException(
-        ProposalErrorMessages.REGISTRATION_FAILED,
-      );
+      throw new BadRequestException(ProposalErrorMessages.REGISTRATION_FAILED);
 
     newProposal.push({ proposal: result, proposalWin: dto.proposalWin });
 
@@ -501,9 +498,9 @@ export class ProposalService {
 
       // Validação: impedir recusa se algum lote estiver em análise
       const hasAllotmentInAnalysis = proposal.allotment?.some(
-        (a) => a.status === AllotmentStatusEnum.emAnalise
+        (a) => a.status === AllotmentStatusEnum.emAnalise,
       );
-      
+
       if (hasAllotmentInAnalysis) {
         throw new BadRequestException(
           ProposalErrorMessages.CANNOT_REFUSE_ALLOTMENT_IN_ANALYSIS,
@@ -553,18 +550,16 @@ export class ProposalService {
 
       // Validação: impedir aceitar se algum lote estiver em análise
       const hasAllotmentInAnalysis = proposal.allotment?.some(
-        (a) => a.status === AllotmentStatusEnum.emAnalise
+        (a) => a.status === AllotmentStatusEnum.emAnalise,
       );
-      
+
       if (hasAllotmentInAnalysis) {
         throw new BadRequestException(
           ProposalErrorMessages.CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS,
         );
       }
 
-      const bid = await this._bidRepository.getById(
-        extractBidId(proposal.bid),
-      );
+      const bid = await this._bidRepository.getById(extractBidId(proposal.bid));
 
       // for (let iterator of proposal.allotment) {
       //   await this._allotmentService.updateStatus(iterator._id.toString(), AllotmentStatusEnum.adjudicado);
@@ -583,12 +578,9 @@ export class ProposalService {
         supplier_id: extractSupplierId(proposal.proposedBy.supplier),
       };
 
-      await this._bidRepository.changeStatus(
-        extractBidId(proposal.bid),
-        {
-          status: BidStatusEnum["completed"],
-        },
-      );
+      await this._bidRepository.changeStatus(extractBidId(proposal.bid), {
+        status: BidStatusEnum["completed"],
+      });
 
       await this._allotmentRepository.updateStatusByIds(
         proposal.allotment.map((item) => item._id.toString()),
@@ -686,7 +678,9 @@ export class ProposalService {
       throw new BadRequestException(ProposalErrorMessages.PROPOSAL_NOT_FOUND);
     }
     if (result.deleted === true) {
-      throw new BadRequestException(ProposalErrorMessages.PROPOSAL_ALREADY_DELETED);
+      throw new BadRequestException(
+        ProposalErrorMessages.PROPOSAL_ALREADY_DELETED,
+      );
     }
     return result;
   }

--- a/src/modules/SOL/services/proposal.service.ts
+++ b/src/modules/SOL/services/proposal.service.ts
@@ -34,6 +34,7 @@ import { AllotmentModel } from "../models/allotment.model";
 import { BidService } from "./bid.service";
 import { ProposalReviewerAcceptUpdateDto } from "../dtos/proposal-accept-reviewer-update.dto";
 import { extractAndCompareContent } from "../utils/string-and-id-compare.helper";
+import { extractBidId, extractSupplierId } from "../utils/entity-id-extractor.helper";
 import { Proposal } from "../schemas/proposal.schema";
 
 @Injectable()
@@ -434,9 +435,7 @@ export class ProposalService {
     const proposal = await this._proposalRepository.getById(proposalId);
 
     const list = await this._proposalRepository.listByBid(
-      typeof proposal.bid === "string"
-        ? proposal.bid
-        : proposal.bid._id || proposal.bid.id,
+      extractBidId(proposal.bid),
     );
 
     if (refusedBy.type !== "administrador") {
@@ -565,9 +564,7 @@ export class ProposalService {
       }
 
       const bid = await this._bidRepository.getById(
-        typeof proposal.bid === "string"
-          ? proposal.bid
-          : proposal.bid._id || proposal.bid.id,
+        extractBidId(proposal.bid),
       );
 
       // for (let iterator of proposal.allotment) {
@@ -576,10 +573,7 @@ export class ProposalService {
 
       let contractDto: ContractRegisterDto = {
         contract_number: "1",
-        bid_number:
-          typeof proposal.bid === "string"
-            ? proposal.bid
-            : proposal.bid._id || proposal.bid.id,
+        bid_number: extractBidId(proposal.bid),
         value: proposal.total_value,
         contract_document: "teste",
         association_accept: false,
@@ -587,17 +581,11 @@ export class ProposalService {
         status: ContractStatusEnum.aguardando_assinaturas,
         proposal_id: [proposal],
         association_id: bid.id,
-        supplier_id:
-          typeof proposal.proposedBy.supplier === "string"
-            ? proposal.proposedBy.supplier
-            : proposal.proposedBy.supplier._id ||
-              proposal.proposedBy.supplier.id,
+        supplier_id: extractSupplierId(proposal.proposedBy.supplier),
       };
 
       await this._bidRepository.changeStatus(
-        typeof proposal.bid === "string"
-          ? proposal.bid
-          : proposal.bid._id || proposal.bid.id,
+        extractBidId(proposal.bid),
         {
           status: BidStatusEnum["completed"],
         },

--- a/src/modules/SOL/services/proposal.service.ts
+++ b/src/modules/SOL/services/proposal.service.ts
@@ -39,7 +39,6 @@ import {
   extractSupplierId,
 } from "../utils/entity-id-extractor.helper";
 import { ProposalErrorMessages } from "../utils/error-messages.helper";
-import { Proposal } from "../schemas/proposal.schema";
 
 @Injectable()
 export class ProposalService {
@@ -56,6 +55,47 @@ export class ProposalService {
     private readonly _bidService: BidService,
   ) {}
 
+  /**
+   * Registra uma nova proposta para uma licitação.
+   *
+   * Regras de Negócio:
+   * 1. Validação Inicial:
+   *    - O usuário que propõe (proposedBy) deve existir
+   *    - A licitação (bid) deve existir e estar com status 'open' ou 'reopened'
+   *
+   * 2. Tipos de Licitação:
+   *    - Para tipo "globalPrice": Uma proposta pode abranger múltiplos lotes
+   *    - Para outros tipos: Uma proposta é específica para um único lote
+   *
+   * 3. Validação de Propostas Existentes:
+   *    - Para tipo "globalPrice": Um fornecedor só pode ter uma proposta por licitação
+   *    - Para outros tipos: Um fornecedor pode ter uma proposta por lote
+   *
+   * 4. Lógica de ProposalWin (Proposta Vencedora):
+   *    Para licitações "globalPrice":
+   *    - Se é a primeira proposta: automaticamente marcada como vencedora
+   *    - Se existem outras propostas:
+   *      * Se o valor total é menor que a menor proposta existente: marca como vencedora
+   *      * Se o valor total é igual à menor proposta: todas com mesmo valor são marcadas como vencedoras
+   *      * Se o valor total é maior: marca como não vencedora
+   *
+   *    Para outros tipos de licitação:
+   *    - Mesma lógica aplicada por lote individualmente
+   *    - Considera o valor total + frete para comparação
+   *
+   * 5. Atualização de Lotes:
+   *    - Cada lote é atualizado com a referência da nova proposta
+   *    - O status de vencedora (proposalWin) é atualizado em cada lote
+   *
+   * @param proposedById - ID do usuário que está fazendo a proposta
+   * @param dto - Dados da proposta incluindo valores, licitação, lotes e demais informações
+   * @returns Promise<ProposalModel> - Retorna a proposta registrada
+   * @throws CustomException
+   *    - Quando a licitação está fechada
+   *    - Quando já existe uma proposta do fornecedor para a licitação (globalPrice)
+   *    - Quando já existe uma proposta do fornecedor para o lote
+   *    - Quando falha ao registrar a proposta
+   */
   async register(
     proposedById: string,
     dto: ProposalRegisterDto,

--- a/src/modules/SOL/services/proposal.service.ts
+++ b/src/modules/SOL/services/proposal.service.ts
@@ -35,6 +35,7 @@ import { BidService } from "./bid.service";
 import { ProposalReviewerAcceptUpdateDto } from "../dtos/proposal-accept-reviewer-update.dto";
 import { extractAndCompareContent } from "../utils/string-and-id-compare.helper";
 import { extractBidId, extractSupplierId } from "../utils/entity-id-extractor.helper";
+import { ProposalErrorMessages } from "../utils/error-messages.helper";
 import { Proposal } from "../schemas/proposal.schema";
 
 @Injectable()
@@ -75,7 +76,7 @@ export class ProposalService {
       BidStatusEnum.reopened !== bid.status
     )
       throw new BadRequestException(
-        "Não é possivel cadastrar proposta para licitação fechada!",
+        ProposalErrorMessages.BID_CLOSED,
       );
 
     dto.bid = bid;
@@ -101,7 +102,7 @@ export class ProposalService {
       }
       if (!result)
         throw new BadRequestException(
-          "Não foi possivel cadastrar essa proposta!",
+          ProposalErrorMessages.REGISTRATION_FAILED,
         );
 
       return result;
@@ -116,7 +117,7 @@ export class ProposalService {
       );
       if (verify) {
         throw new BadRequestException(
-          "Já foi enviado uma proposta para essa licitação!",
+          ProposalErrorMessages.DUPLICATE_PROPOSAL,
         );
       }
     }
@@ -146,7 +147,7 @@ export class ProposalService {
 
         if (verify) {
           throw new BadRequestException(
-            "Já foi enviado uma proposta para essa licitação!",
+            ProposalErrorMessages.DUPLICATE_PROPOSAL,
           );
         }
       });
@@ -332,7 +333,7 @@ export class ProposalService {
     const result = await this._proposalRepository.register(dto);
     if (!result)
       throw new BadRequestException(
-        "Não foi possivel cadastrar essa proposta!",
+        ProposalErrorMessages.REGISTRATION_FAILED,
       );
 
     newProposal.push({ proposal: result, proposalWin: dto.proposalWin });
@@ -355,7 +356,7 @@ export class ProposalService {
   ): Promise<ProposalModel> {
     const item = await this._proposalRepository.getById(_id);
     if (!item) {
-      throw new BadRequestException("Proposta não encontrada!");
+      throw new BadRequestException(ProposalErrorMessages.PROPOSAL_NOT_FOUND);
     }
 
     const result = await this._proposalRepository.updateAcceptSupplier(
@@ -377,7 +378,7 @@ export class ProposalService {
   ): Promise<ProposalModel> {
     const item = await this._proposalRepository.getById(_id);
     if (!item) {
-      throw new BadRequestException("Proposta não encontrada!");
+      throw new BadRequestException(ProposalErrorMessages.PROPOSAL_NOT_FOUND);
     }
 
     const result = await this._proposalRepository.updateAcceptAssociation(
@@ -401,7 +402,7 @@ export class ProposalService {
   ): Promise<ProposalModel | any> {
     const item = await this._proposalRepository.getById(_id);
     if (!item) {
-      throw new BadRequestException("Proposta não encontrada!");
+      throw new BadRequestException(ProposalErrorMessages.PROPOSAL_NOT_FOUND);
     }
     const result = await this._proposalRepository.updateAcceptReviewer(
       _id,
@@ -505,7 +506,7 @@ export class ProposalService {
       
       if (hasAllotmentInAnalysis) {
         throw new BadRequestException(
-          "Não é possível recusar propostas enquanto o lote está em análise.",
+          ProposalErrorMessages.CANNOT_REFUSE_ALLOTMENT_IN_ANALYSIS,
         );
       }
       const dto = {
@@ -557,7 +558,7 @@ export class ProposalService {
       
       if (hasAllotmentInAnalysis) {
         throw new BadRequestException(
-          "Não é possível aceitar propostas enquanto o lote está em análise.",
+          ProposalErrorMessages.CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS,
         );
       }
 
@@ -624,7 +625,7 @@ export class ProposalService {
   ): Promise<ProposalModel> {
     const item = await this._proposalRepository.getById(_id);
     if (!item) {
-      throw new BadRequestException("Proposta não encontrada!");
+      throw new BadRequestException(ProposalErrorMessages.PROPOSAL_NOT_FOUND);
     }
 
     const result = await this._proposalRepository.updateStatus(_id, dto);
@@ -660,7 +661,7 @@ export class ProposalService {
   ): Promise<ProposalModel> {
     const item = await this._proposalRepository.getById(_id);
     if (!item) {
-      throw new BadRequestException("Proposta não encontrada!");
+      throw new BadRequestException(ProposalErrorMessages.PROPOSAL_NOT_FOUND);
     }
     const result = await this._proposalRepository.addItem(_id, dto);
     return result;
@@ -672,7 +673,7 @@ export class ProposalService {
   ): Promise<ProposalModel> {
     const item = await this._proposalRepository.getById(_id);
     if (!item) {
-      throw new BadRequestException("Proposta não encontrada!");
+      throw new BadRequestException(ProposalErrorMessages.PROPOSAL_NOT_FOUND);
     }
     const result = await this._proposalRepository.removeItem(_id, dto);
     return result;
@@ -682,10 +683,10 @@ export class ProposalService {
     const result = await this._proposalRepository.getById(_id);
 
     if (!result) {
-      throw new BadRequestException("Proposta não encontrada!");
+      throw new BadRequestException(ProposalErrorMessages.PROPOSAL_NOT_FOUND);
     }
     if (result.deleted === true) {
-      throw new BadRequestException("Esse contrato já foi deletado!");
+      throw new BadRequestException(ProposalErrorMessages.PROPOSAL_ALREADY_DELETED);
     }
     return result;
   }

--- a/src/modules/SOL/services/proposal.service.ts
+++ b/src/modules/SOL/services/proposal.service.ts
@@ -547,7 +547,7 @@ export class ProposalService {
           (a) => a.status === AllotmentStatusEnum.emAnalise,
         );
         StructuredErrorHelper.throwCannotAcceptAllotmentInAnalysis(
-          allotmentInAnalysis?._id?.toString() || 'unknown'
+          allotmentInAnalysis?._id?.toString() || "unknown",
         );
       }
       const dto = {
@@ -602,7 +602,7 @@ export class ProposalService {
           (a) => a.status === AllotmentStatusEnum.emAnalise,
         );
         StructuredErrorHelper.throwCannotAcceptAllotmentInAnalysis(
-          allotmentInAnalysis?._id?.toString() || 'unknown'
+          allotmentInAnalysis?._id?.toString() || "unknown",
         );
       }
 

--- a/src/modules/SOL/services/proposal.service.ts
+++ b/src/modules/SOL/services/proposal.service.ts
@@ -499,12 +499,11 @@ export class ProposalService {
       const proposal = await this._proposalRepository.getById(proposalId);
 
       // Validação: impedir recusa se algum lote estiver em análise
-      if (
-        proposal.allotment &&
-        proposal.allotment.some(
-          (a) => a.status === AllotmentStatusEnum.emAnalise,
-        )
-      ) {
+      const hasAllotmentInAnalysis = proposal.allotment?.some(
+        (a) => a.status === AllotmentStatusEnum.emAnalise
+      );
+      
+      if (hasAllotmentInAnalysis) {
         throw new BadRequestException(
           "Não é possível recusar propostas enquanto o lote está em análise.",
         );

--- a/src/modules/SOL/services/proposal.service.ts
+++ b/src/modules/SOL/services/proposal.service.ts
@@ -433,7 +433,9 @@ export class ProposalService {
 
     const proposal = await this._proposalRepository.getById(proposalId);
 
-    const list = await this._proposalRepository.listByBid(proposal.bid.id);
+    const list = await this._proposalRepository.listByBid(
+  typeof proposal.bid === 'string' ? proposal.bid : proposal.bid._id || proposal.bid.id
+);
 
     if (refusedBy.type !== "administrador") {
       if (list.length > 1) {
@@ -494,6 +496,11 @@ export class ProposalService {
     if (acceptBy.type === UserTypeEnum.associacao) {
       obj.status = ProposalStatusEnum.aceitoAssociacao;
       const proposal = await this._proposalRepository.getById(proposalId);
+
+      // Validação: impedir recusa se algum lote estiver em análise
+      if (proposal.allotment && proposal.allotment.some(a => a.status === AllotmentStatusEnum.emAnalise)) {
+        throw new BadRequestException('Não é possível recusar propostas enquanto o lote está em análise.');
+      }
       const dto = {
         association_accept: true,
       };
@@ -536,7 +543,14 @@ export class ProposalService {
 
       const proposal = await this._proposalRepository.getById(proposalId);
 
-      const bid = await this._bidRepository.getById(proposal.bid.id);
+      // Validação: impedir aceitar se algum lote estiver em análise
+      if (proposal.allotment && proposal.allotment.some(a => a.status === AllotmentStatusEnum.emAnalise)) {
+        throw new BadRequestException('Não é possível aceitar propostas enquanto o lote está em análise.');
+      }
+
+      const bid = await this._bidRepository.getById(
+  typeof proposal.bid === 'string' ? proposal.bid : proposal.bid._id || proposal.bid.id
+);
 
       // for (let iterator of proposal.allotment) {
       //   await this._allotmentService.updateStatus(iterator._id.toString(), AllotmentStatusEnum.adjudicado);
@@ -544,7 +558,7 @@ export class ProposalService {
 
       let contractDto: ContractRegisterDto = {
         contract_number: "1",
-        bid_number: proposal.bid.id,
+        bid_number: typeof proposal.bid === 'string' ? proposal.bid : proposal.bid._id || proposal.bid.id,
         value: proposal.total_value,
         contract_document: "teste",
         association_accept: false,
@@ -552,10 +566,12 @@ export class ProposalService {
         status: ContractStatusEnum.aguardando_assinaturas,
         proposal_id: [proposal],
         association_id: bid.id,
-        supplier_id: proposal.proposedBy.supplier.id,
+        supplier_id: typeof proposal.proposedBy.supplier === 'string' ? proposal.proposedBy.supplier : proposal.proposedBy.supplier._id || proposal.proposedBy.supplier.id,
       };
 
-      await this._bidRepository.changeStatus(proposal.bid.id, {
+      await this._bidRepository.changeStatus(
+  typeof proposal.bid === 'string' ? proposal.bid : proposal.bid._id || proposal.bid.id,
+  {
         status: BidStatusEnum["completed"],
       });
 

--- a/src/modules/SOL/services/proposal.service.ts
+++ b/src/modules/SOL/services/proposal.service.ts
@@ -551,12 +551,11 @@ export class ProposalService {
       const proposal = await this._proposalRepository.getById(proposalId);
 
       // Validação: impedir aceitar se algum lote estiver em análise
-      if (
-        proposal.allotment &&
-        proposal.allotment.some(
-          (a) => a.status === AllotmentStatusEnum.emAnalise,
-        )
-      ) {
+      const hasAllotmentInAnalysis = proposal.allotment?.some(
+        (a) => a.status === AllotmentStatusEnum.emAnalise
+      );
+      
+      if (hasAllotmentInAnalysis) {
         throw new BadRequestException(
           "Não é possível aceitar propostas enquanto o lote está em análise.",
         );

--- a/src/modules/SOL/services/proposal.service.ts
+++ b/src/modules/SOL/services/proposal.service.ts
@@ -434,8 +434,10 @@ export class ProposalService {
     const proposal = await this._proposalRepository.getById(proposalId);
 
     const list = await this._proposalRepository.listByBid(
-  typeof proposal.bid === 'string' ? proposal.bid : proposal.bid._id || proposal.bid.id
-);
+      typeof proposal.bid === "string"
+        ? proposal.bid
+        : proposal.bid._id || proposal.bid.id,
+    );
 
     if (refusedBy.type !== "administrador") {
       if (list.length > 1) {
@@ -498,8 +500,15 @@ export class ProposalService {
       const proposal = await this._proposalRepository.getById(proposalId);
 
       // Validação: impedir recusa se algum lote estiver em análise
-      if (proposal.allotment && proposal.allotment.some(a => a.status === AllotmentStatusEnum.emAnalise)) {
-        throw new BadRequestException('Não é possível recusar propostas enquanto o lote está em análise.');
+      if (
+        proposal.allotment &&
+        proposal.allotment.some(
+          (a) => a.status === AllotmentStatusEnum.emAnalise,
+        )
+      ) {
+        throw new BadRequestException(
+          "Não é possível recusar propostas enquanto o lote está em análise.",
+        );
       }
       const dto = {
         association_accept: true,
@@ -544,13 +553,22 @@ export class ProposalService {
       const proposal = await this._proposalRepository.getById(proposalId);
 
       // Validação: impedir aceitar se algum lote estiver em análise
-      if (proposal.allotment && proposal.allotment.some(a => a.status === AllotmentStatusEnum.emAnalise)) {
-        throw new BadRequestException('Não é possível aceitar propostas enquanto o lote está em análise.');
+      if (
+        proposal.allotment &&
+        proposal.allotment.some(
+          (a) => a.status === AllotmentStatusEnum.emAnalise,
+        )
+      ) {
+        throw new BadRequestException(
+          "Não é possível aceitar propostas enquanto o lote está em análise.",
+        );
       }
 
       const bid = await this._bidRepository.getById(
-  typeof proposal.bid === 'string' ? proposal.bid : proposal.bid._id || proposal.bid.id
-);
+        typeof proposal.bid === "string"
+          ? proposal.bid
+          : proposal.bid._id || proposal.bid.id,
+      );
 
       // for (let iterator of proposal.allotment) {
       //   await this._allotmentService.updateStatus(iterator._id.toString(), AllotmentStatusEnum.adjudicado);
@@ -558,7 +576,10 @@ export class ProposalService {
 
       let contractDto: ContractRegisterDto = {
         contract_number: "1",
-        bid_number: typeof proposal.bid === 'string' ? proposal.bid : proposal.bid._id || proposal.bid.id,
+        bid_number:
+          typeof proposal.bid === "string"
+            ? proposal.bid
+            : proposal.bid._id || proposal.bid.id,
         value: proposal.total_value,
         contract_document: "teste",
         association_accept: false,
@@ -566,14 +587,21 @@ export class ProposalService {
         status: ContractStatusEnum.aguardando_assinaturas,
         proposal_id: [proposal],
         association_id: bid.id,
-        supplier_id: typeof proposal.proposedBy.supplier === 'string' ? proposal.proposedBy.supplier : proposal.proposedBy.supplier._id || proposal.proposedBy.supplier.id,
+        supplier_id:
+          typeof proposal.proposedBy.supplier === "string"
+            ? proposal.proposedBy.supplier
+            : proposal.proposedBy.supplier._id ||
+              proposal.proposedBy.supplier.id,
       };
 
       await this._bidRepository.changeStatus(
-  typeof proposal.bid === 'string' ? proposal.bid : proposal.bid._id || proposal.bid.id,
-  {
-        status: BidStatusEnum["completed"],
-      });
+        typeof proposal.bid === "string"
+          ? proposal.bid
+          : proposal.bid._id || proposal.bid.id,
+        {
+          status: BidStatusEnum["completed"],
+        },
+      );
 
       await this._allotmentRepository.updateStatusByIds(
         proposal.allotment.map((item) => item._id.toString()),

--- a/src/modules/SOL/services/proposal.service.ts
+++ b/src/modules/SOL/services/proposal.service.ts
@@ -503,7 +503,7 @@ export class ProposalService {
 
       if (hasAllotmentInAnalysis) {
         throw new BadRequestException(
-          ProposalErrorMessages.CANNOT_REFUSE_ALLOTMENT_IN_ANALYSIS,
+          ProposalErrorMessages.CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS,
         );
       }
       const dto = {

--- a/src/modules/SOL/utils/entity-id-extractor.helper.ts
+++ b/src/modules/SOL/utils/entity-id-extractor.helper.ts
@@ -8,15 +8,15 @@
  * @returns The bid ID as string
  */
 export function extractBidId(bid: any): string {
-  if (typeof bid === 'string') {
+  if (typeof bid === "string") {
     return bid;
   }
-  
-  if (bid && typeof bid === 'object') {
+
+  if (bid && typeof bid === "object") {
     return bid._id?.toString() || bid.id?.toString();
   }
-  
-  throw new Error('Invalid bid entity: cannot extract ID');
+
+  throw new Error("Invalid bid entity: cannot extract ID");
 }
 
 /**
@@ -25,15 +25,15 @@ export function extractBidId(bid: any): string {
  * @returns The supplier ID as string
  */
 export function extractSupplierId(supplier: any): string {
-  if (typeof supplier === 'string') {
+  if (typeof supplier === "string") {
     return supplier;
   }
-  
-  if (supplier && typeof supplier === 'object') {
+
+  if (supplier && typeof supplier === "object") {
     return supplier._id?.toString() || supplier.id?.toString();
   }
-  
-  throw new Error('Invalid supplier entity: cannot extract ID');
+
+  throw new Error("Invalid supplier entity: cannot extract ID");
 }
 
 /**
@@ -42,13 +42,13 @@ export function extractSupplierId(supplier: any): string {
  * @returns The entity ID as string
  */
 export function extractEntityId(entity: any): string {
-  if (typeof entity === 'string') {
+  if (typeof entity === "string") {
     return entity;
   }
-  
-  if (entity && typeof entity === 'object') {
+
+  if (entity && typeof entity === "object") {
     return entity._id?.toString() || entity.id?.toString();
   }
-  
-  throw new Error('Invalid entity: cannot extract ID');
+
+  throw new Error("Invalid entity: cannot extract ID");
 }

--- a/src/modules/SOL/utils/entity-id-extractor.helper.ts
+++ b/src/modules/SOL/utils/entity-id-extractor.helper.ts
@@ -1,0 +1,54 @@
+/**
+ * Utility functions to safely extract IDs from entities that may be populated or not
+ */
+
+/**
+ * Extracts ID from a bid entity that can be either a string ID or a populated object
+ * @param bid - The bid entity (string ID or populated object)
+ * @returns The bid ID as string
+ */
+export function extractBidId(bid: any): string {
+  if (typeof bid === 'string') {
+    return bid;
+  }
+  
+  if (bid && typeof bid === 'object') {
+    return bid._id?.toString() || bid.id?.toString();
+  }
+  
+  throw new Error('Invalid bid entity: cannot extract ID');
+}
+
+/**
+ * Extracts ID from a supplier entity that can be either a string ID or a populated object
+ * @param supplier - The supplier entity (string ID or populated object)
+ * @returns The supplier ID as string
+ */
+export function extractSupplierId(supplier: any): string {
+  if (typeof supplier === 'string') {
+    return supplier;
+  }
+  
+  if (supplier && typeof supplier === 'object') {
+    return supplier._id?.toString() || supplier.id?.toString();
+  }
+  
+  throw new Error('Invalid supplier entity: cannot extract ID');
+}
+
+/**
+ * Extracts ID from any entity that can be either a string ID or a populated object
+ * @param entity - The entity (string ID or populated object)
+ * @returns The entity ID as string
+ */
+export function extractEntityId(entity: any): string {
+  if (typeof entity === 'string') {
+    return entity;
+  }
+  
+  if (entity && typeof entity === 'object') {
+    return entity._id?.toString() || entity.id?.toString();
+  }
+  
+  throw new Error('Invalid entity: cannot extract ID');
+}

--- a/src/modules/SOL/utils/error-messages.helper.ts
+++ b/src/modules/SOL/utils/error-messages.helper.ts
@@ -1,0 +1,23 @@
+/**
+ * Centralized error messages for ProposalService
+ * Organized by context for easy maintenance and localization
+ */
+
+export const ProposalErrorMessages = {
+  // Proposal not found
+  PROPOSAL_NOT_FOUND: "Proposta não encontrada!",
+  
+  // Proposal already deleted
+  PROPOSAL_ALREADY_DELETED: "Esse contrato já foi deletado!",
+  
+  // Registration errors
+  BID_CLOSED: "Não é possivel cadastrar proposta para licitação fechada!",
+  REGISTRATION_FAILED: "Não foi possivel cadastrar essa proposta!",
+  DUPLICATE_PROPOSAL: "Já foi enviado uma proposta para essa licitação!",
+  
+  // Allotment analysis errors
+  CANNOT_REFUSE_ALLOTMENT_IN_ANALYSIS: "Não é possível recusar propostas enquanto o lote está em análise.",
+  CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS: "Não é possível aceitar propostas enquanto o lote está em análise.",
+} as const;
+
+export type ProposalErrorMessageKey = keyof typeof ProposalErrorMessages;

--- a/src/modules/SOL/utils/error-messages.helper.ts
+++ b/src/modules/SOL/utils/error-messages.helper.ts
@@ -1,23 +1,20 @@
-/**
- * Centralized error messages for ProposalService
- * Organized by context for easy maintenance and localization
- */
-
 export const ProposalErrorMessages = {
   // Proposal not found
   PROPOSAL_NOT_FOUND: "Proposta não encontrada!",
-  
+
   // Proposal already deleted
   PROPOSAL_ALREADY_DELETED: "Esse contrato já foi deletado!",
-  
+
   // Registration errors
   BID_CLOSED: "Não é possivel cadastrar proposta para licitação fechada!",
   REGISTRATION_FAILED: "Não foi possivel cadastrar essa proposta!",
   DUPLICATE_PROPOSAL: "Já foi enviado uma proposta para essa licitação!",
-  
+
   // Allotment analysis errors
-  CANNOT_REFUSE_ALLOTMENT_IN_ANALYSIS: "Não é possível recusar propostas enquanto o lote está em análise.",
-  CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS: "Não é possível aceitar propostas enquanto o lote está em análise.",
+  CANNOT_REFUSE_ALLOTMENT_IN_ANALYSIS:
+    "Não é possível recusar propostas enquanto o lote está em análise.",
+  CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS:
+    "Não é possível aceitar propostas enquanto o lote está em análise.",
 } as const;
 
 export type ProposalErrorMessageKey = keyof typeof ProposalErrorMessages;

--- a/src/modules/SOL/utils/error-messages.helper.ts
+++ b/src/modules/SOL/utils/error-messages.helper.ts
@@ -1,20 +1,18 @@
 export const ProposalErrorMessages = {
   // Proposal not found
-  PROPOSAL_NOT_FOUND: "Proposta não encontrada!",
+  PROPOSAL_NOT_FOUND: "PROPOSAL_NOT_FOUND",
 
   // Proposal already deleted
-  PROPOSAL_ALREADY_DELETED: "Esse contrato já foi deletado!",
+  PROPOSAL_ALREADY_DELETED: "PROPOSAL_ALREADY_DELETED",
 
   // Registration errors
-  BID_CLOSED: "Não é possivel cadastrar proposta para licitação fechada!",
-  REGISTRATION_FAILED: "Não foi possivel cadastrar essa proposta!",
-  DUPLICATE_PROPOSAL: "Já foi enviado uma proposta para essa licitação!",
+  BID_CLOSED: "BID_CLOSED",
+  REGISTRATION_FAILED: "REGISTRATION_FAILED",
+  DUPLICATE_PROPOSAL: "DUPLICATE_PROPOSAL",
 
   // Allotment analysis errors
-  CANNOT_REFUSE_ALLOTMENT_IN_ANALYSIS:
-    "Não é possível recusar propostas enquanto o lote está em análise.",
-  CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS:
-    "Não é possível aceitar propostas enquanto o lote está em análise.",
+  CANNOT_REFUSE_ALLOTMENT_IN_ANALYSIS: "CANNOT_REFUSE_ALLOTMENT_IN_ANALYSIS",
+  CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS: "CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS",
 } as const;
 
 export type ProposalErrorMessageKey = keyof typeof ProposalErrorMessages;

--- a/src/shared/enums/errors.ts
+++ b/src/shared/enums/errors.ts
@@ -1,0 +1,21 @@
+import { HttpStatus } from "@nestjs/common";
+
+/**
+ * Enum que representa o erro, deve-se criar também as informações do erro em `BackendErrorsInfo`.
+ * Alert: O frontend deve mapear esses erros para mensagens amigáveis ao usuário.
+ */
+export enum BackendErrors {
+  PROPOSAL_NOT_FOUND = "PROPOSAL_NOT_FOUND",
+}
+
+export const BackendErrorsInfo = {
+  [BackendErrors.PROPOSAL_NOT_FOUND]: {
+    code: HttpStatus.NOT_FOUND,
+    data: ["proposal_id"] as const,
+  },
+} satisfies Record<BackendErrors, ErrorInfoProps>;
+
+type ErrorInfoProps = {
+  code: HttpStatus;
+  data: readonly string[];
+};

--- a/src/shared/enums/errors.ts
+++ b/src/shared/enums/errors.ts
@@ -19,6 +19,10 @@ export enum BackendErrors {
   BID_NOT_IN_ANALYSIS = "BID_NOT_IN_ANALYSIS",
   BID_NO_PROPOSALS_FOR_TIE_BREAKER = "BID_NO_PROPOSALS_FOR_TIE_BREAKER",
   BID_MISSING_ALLOTMENTS = "BID_MISSING_ALLOTMENTS",
+  BID_INVALID_STATUS = "BID_INVALID_STATUS",
+  BID_DOCUMENT_GENERATION_FAILED = "BID_DOCUMENT_GENERATION_FAILED",
+  BID_DOWNLOAD_FAILED = "BID_DOWNLOAD_FAILED",
+  BID_UNAUTHORIZED_ACCESS = "BID_UNAUTHORIZED_ACCESS",
   
   // Association errors
   ASSOCIATION_NOT_FOUND = "ASSOCIATION_NOT_FOUND",
@@ -29,6 +33,13 @@ export enum BackendErrors {
   
   // User errors
   USER_NOT_FOUND = "USER_NOT_FOUND",
+  USER_REGISTRATION_FAILED = "USER_REGISTRATION_FAILED",
+  USER_UPDATE_FAILED = "USER_UPDATE_FAILED",
+  USER_EMAIL_ALREADY_EXISTS = "USER_EMAIL_ALREADY_EXISTS",
+  USER_INVALID_CREDENTIALS = "USER_INVALID_CREDENTIALS",
+  USER_PASSWORD_UPDATE_FAILED = "USER_PASSWORD_UPDATE_FAILED",
+  USER_VERIFICATION_CODE_INVALID = "USER_VERIFICATION_CODE_INVALID",
+  USER_VERIFICATION_CODE_EXPIRED = "USER_VERIFICATION_CODE_EXPIRED",
   
   // Supplier errors
   SUPPLIER_NOT_FOUND = "SUPPLIER_NOT_FOUND",
@@ -100,6 +111,22 @@ export const BackendErrorsInfo = {
     code: HttpStatus.BAD_REQUEST,
     data: [] as const,
   },
+  [BackendErrors.BID_INVALID_STATUS]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: ["bid_id", "status"] as const,
+  },
+  [BackendErrors.BID_DOCUMENT_GENERATION_FAILED]: {
+    code: HttpStatus.INTERNAL_SERVER_ERROR,
+    data: ["bid_id"] as const,
+  },
+  [BackendErrors.BID_DOWNLOAD_FAILED]: {
+    code: HttpStatus.INTERNAL_SERVER_ERROR,
+    data: ["bid_id", "file_type"] as const,
+  },
+  [BackendErrors.BID_UNAUTHORIZED_ACCESS]: {
+    code: HttpStatus.FORBIDDEN,
+    data: ["bid_id"] as const,
+  },
   
   // Association errors
   [BackendErrors.ASSOCIATION_NOT_FOUND]: {
@@ -121,6 +148,34 @@ export const BackendErrorsInfo = {
   [BackendErrors.USER_NOT_FOUND]: {
     code: HttpStatus.NOT_FOUND,
     data: ["user_id"] as const,
+  },
+  [BackendErrors.USER_REGISTRATION_FAILED]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: [] as const,
+  },
+  [BackendErrors.USER_UPDATE_FAILED]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: ["user_id"] as const,
+  },
+  [BackendErrors.USER_EMAIL_ALREADY_EXISTS]: {
+    code: HttpStatus.CONFLICT,
+    data: ["email"] as const,
+  },
+  [BackendErrors.USER_INVALID_CREDENTIALS]: {
+    code: HttpStatus.UNAUTHORIZED,
+    data: [] as const,
+  },
+  [BackendErrors.USER_PASSWORD_UPDATE_FAILED]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: ["user_id"] as const,
+  },
+  [BackendErrors.USER_VERIFICATION_CODE_INVALID]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: ["code"] as const,
+  },
+  [BackendErrors.USER_VERIFICATION_CODE_EXPIRED]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: ["code"] as const,
   },
   
   // Supplier errors

--- a/src/shared/enums/errors.ts
+++ b/src/shared/enums/errors.ts
@@ -10,7 +10,7 @@ export enum BackendErrors {
   PROPOSAL_ALREADY_DELETED = "PROPOSAL_ALREADY_DELETED",
   PROPOSAL_REGISTRATION_FAILED = "PROPOSAL_REGISTRATION_FAILED",
   PROPOSAL_UPDATE_FAILED = "PROPOSAL_UPDATE_FAILED",
-  
+
   // Bid errors
   BID_NOT_FOUND = "BID_NOT_FOUND",
   BID_CLOSED = "BID_CLOSED",
@@ -23,14 +23,14 @@ export enum BackendErrors {
   BID_DOCUMENT_GENERATION_FAILED = "BID_DOCUMENT_GENERATION_FAILED",
   BID_DOWNLOAD_FAILED = "BID_DOWNLOAD_FAILED",
   BID_UNAUTHORIZED_ACCESS = "BID_UNAUTHORIZED_ACCESS",
-  
+
   // Association errors
   ASSOCIATION_NOT_FOUND = "ASSOCIATION_NOT_FOUND",
   ASSOCIATION_REGISTRATION_FAILED = "ASSOCIATION_REGISTRATION_FAILED",
-  
+
   // Agreement errors
   AGREEMENT_NOT_FOUND = "AGREEMENT_NOT_FOUND",
-  
+
   // User errors
   USER_NOT_FOUND = "USER_NOT_FOUND",
   USER_REGISTRATION_FAILED = "USER_REGISTRATION_FAILED",
@@ -40,24 +40,24 @@ export enum BackendErrors {
   USER_PASSWORD_UPDATE_FAILED = "USER_PASSWORD_UPDATE_FAILED",
   USER_VERIFICATION_CODE_INVALID = "USER_VERIFICATION_CODE_INVALID",
   USER_VERIFICATION_CODE_EXPIRED = "USER_VERIFICATION_CODE_EXPIRED",
-  
+
   // Supplier errors
   SUPPLIER_NOT_FOUND = "SUPPLIER_NOT_FOUND",
   SUPPLIER_NO_BIDS = "SUPPLIER_NO_BIDS",
-  
+
   // Allotment errors
   ALLOTMENT_NOT_FOUND = "ALLOTMENT_NOT_FOUND",
   ALLOTMENT_REGISTRATION_FAILED = "ALLOTMENT_REGISTRATION_FAILED",
   ALLOTMENT_UNDER_ANALYSIS = "ALLOTMENT_UNDER_ANALYSIS",
   CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS = "CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS",
-  
+
   // File errors
   FILE_NOT_FOUND = "FILE_NOT_FOUND",
   FILE_CONVERSION_ERROR = "FILE_CONVERSION_ERROR",
-  
+
   // Platform errors
   PLATFORM_CONFIG_NOT_FOUND = "PLATFORM_CONFIG_NOT_FOUND",
-  
+
   // Generic errors
   MISSING_REQUIRED_FIELDS = "MISSING_REQUIRED_FIELDS",
   GENERIC_ERROR = "GENERIC_ERROR",
@@ -81,7 +81,7 @@ export const BackendErrorsInfo = {
     code: HttpStatus.BAD_REQUEST,
     data: ["proposal_id"] as const,
   },
-  
+
   // Bid errors
   [BackendErrors.BID_NOT_FOUND]: {
     code: HttpStatus.NOT_FOUND,
@@ -127,7 +127,7 @@ export const BackendErrorsInfo = {
     code: HttpStatus.FORBIDDEN,
     data: ["bid_id"] as const,
   },
-  
+
   // Association errors
   [BackendErrors.ASSOCIATION_NOT_FOUND]: {
     code: HttpStatus.NOT_FOUND,
@@ -137,13 +137,13 @@ export const BackendErrorsInfo = {
     code: HttpStatus.BAD_REQUEST,
     data: [] as const,
   },
-  
+
   // Agreement errors
   [BackendErrors.AGREEMENT_NOT_FOUND]: {
     code: HttpStatus.NOT_FOUND,
     data: ["agreement_id"] as const,
   },
-  
+
   // User errors
   [BackendErrors.USER_NOT_FOUND]: {
     code: HttpStatus.NOT_FOUND,
@@ -177,7 +177,7 @@ export const BackendErrorsInfo = {
     code: HttpStatus.BAD_REQUEST,
     data: ["code"] as const,
   },
-  
+
   // Supplier errors
   [BackendErrors.SUPPLIER_NOT_FOUND]: {
     code: HttpStatus.NOT_FOUND,
@@ -187,7 +187,7 @@ export const BackendErrorsInfo = {
     code: HttpStatus.NOT_FOUND,
     data: ["supplier_id"] as const,
   },
-  
+
   // Allotment errors
   [BackendErrors.ALLOTMENT_NOT_FOUND]: {
     code: HttpStatus.NOT_FOUND,
@@ -205,7 +205,7 @@ export const BackendErrorsInfo = {
     code: HttpStatus.BAD_REQUEST,
     data: ["allotment_id"] as const,
   },
-  
+
   // File errors
   [BackendErrors.FILE_NOT_FOUND]: {
     code: HttpStatus.NOT_FOUND,
@@ -215,13 +215,13 @@ export const BackendErrorsInfo = {
     code: HttpStatus.INTERNAL_SERVER_ERROR,
     data: [] as const,
   },
-  
+
   // Platform errors
   [BackendErrors.PLATFORM_CONFIG_NOT_FOUND]: {
     code: HttpStatus.NOT_FOUND,
     data: [] as const,
   },
-  
+
   // Generic errors
   [BackendErrors.MISSING_REQUIRED_FIELDS]: {
     code: HttpStatus.BAD_REQUEST,

--- a/src/shared/enums/errors.ts
+++ b/src/shared/enums/errors.ts
@@ -5,13 +5,176 @@ import { HttpStatus } from "@nestjs/common";
  * Alert: O frontend deve mapear esses erros para mensagens amigáveis ao usuário.
  */
 export enum BackendErrors {
+  // Proposal errors
   PROPOSAL_NOT_FOUND = "PROPOSAL_NOT_FOUND",
+  PROPOSAL_ALREADY_DELETED = "PROPOSAL_ALREADY_DELETED",
+  PROPOSAL_REGISTRATION_FAILED = "PROPOSAL_REGISTRATION_FAILED",
+  PROPOSAL_UPDATE_FAILED = "PROPOSAL_UPDATE_FAILED",
+  
+  // Bid errors
+  BID_NOT_FOUND = "BID_NOT_FOUND",
+  BID_CLOSED = "BID_CLOSED",
+  BID_REGISTRATION_FAILED = "BID_REGISTRATION_FAILED",
+  BID_UPDATE_FAILED = "BID_UPDATE_FAILED",
+  BID_NOT_IN_ANALYSIS = "BID_NOT_IN_ANALYSIS",
+  BID_NO_PROPOSALS_FOR_TIE_BREAKER = "BID_NO_PROPOSALS_FOR_TIE_BREAKER",
+  BID_MISSING_ALLOTMENTS = "BID_MISSING_ALLOTMENTS",
+  
+  // Association errors
+  ASSOCIATION_NOT_FOUND = "ASSOCIATION_NOT_FOUND",
+  ASSOCIATION_REGISTRATION_FAILED = "ASSOCIATION_REGISTRATION_FAILED",
+  
+  // Agreement errors
+  AGREEMENT_NOT_FOUND = "AGREEMENT_NOT_FOUND",
+  
+  // User errors
+  USER_NOT_FOUND = "USER_NOT_FOUND",
+  
+  // Supplier errors
+  SUPPLIER_NOT_FOUND = "SUPPLIER_NOT_FOUND",
+  SUPPLIER_NO_BIDS = "SUPPLIER_NO_BIDS",
+  
+  // Allotment errors
+  ALLOTMENT_NOT_FOUND = "ALLOTMENT_NOT_FOUND",
+  ALLOTMENT_REGISTRATION_FAILED = "ALLOTMENT_REGISTRATION_FAILED",
+  ALLOTMENT_UNDER_ANALYSIS = "ALLOTMENT_UNDER_ANALYSIS",
+  CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS = "CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS",
+  
+  // File errors
+  FILE_NOT_FOUND = "FILE_NOT_FOUND",
+  FILE_CONVERSION_ERROR = "FILE_CONVERSION_ERROR",
+  
+  // Platform errors
+  PLATFORM_CONFIG_NOT_FOUND = "PLATFORM_CONFIG_NOT_FOUND",
+  
+  // Generic errors
+  MISSING_REQUIRED_FIELDS = "MISSING_REQUIRED_FIELDS",
+  GENERIC_ERROR = "GENERIC_ERROR",
 }
 
 export const BackendErrorsInfo = {
+  // Proposal errors
   [BackendErrors.PROPOSAL_NOT_FOUND]: {
     code: HttpStatus.NOT_FOUND,
     data: ["proposal_id"] as const,
+  },
+  [BackendErrors.PROPOSAL_ALREADY_DELETED]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: ["proposal_id"] as const,
+  },
+  [BackendErrors.PROPOSAL_REGISTRATION_FAILED]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: [] as const,
+  },
+  [BackendErrors.PROPOSAL_UPDATE_FAILED]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: ["proposal_id"] as const,
+  },
+  
+  // Bid errors
+  [BackendErrors.BID_NOT_FOUND]: {
+    code: HttpStatus.NOT_FOUND,
+    data: ["bid_id"] as const,
+  },
+  [BackendErrors.BID_CLOSED]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: ["bid_id"] as const,
+  },
+  [BackendErrors.BID_REGISTRATION_FAILED]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: [] as const,
+  },
+  [BackendErrors.BID_UPDATE_FAILED]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: ["bid_id"] as const,
+  },
+  [BackendErrors.BID_NOT_IN_ANALYSIS]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: ["bid_id"] as const,
+  },
+  [BackendErrors.BID_NO_PROPOSALS_FOR_TIE_BREAKER]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: ["bid_id"] as const,
+  },
+  [BackendErrors.BID_MISSING_ALLOTMENTS]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: [] as const,
+  },
+  
+  // Association errors
+  [BackendErrors.ASSOCIATION_NOT_FOUND]: {
+    code: HttpStatus.NOT_FOUND,
+    data: ["association_id"] as const,
+  },
+  [BackendErrors.ASSOCIATION_REGISTRATION_FAILED]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: [] as const,
+  },
+  
+  // Agreement errors
+  [BackendErrors.AGREEMENT_NOT_FOUND]: {
+    code: HttpStatus.NOT_FOUND,
+    data: ["agreement_id"] as const,
+  },
+  
+  // User errors
+  [BackendErrors.USER_NOT_FOUND]: {
+    code: HttpStatus.NOT_FOUND,
+    data: ["user_id"] as const,
+  },
+  
+  // Supplier errors
+  [BackendErrors.SUPPLIER_NOT_FOUND]: {
+    code: HttpStatus.NOT_FOUND,
+    data: ["supplier_id"] as const,
+  },
+  [BackendErrors.SUPPLIER_NO_BIDS]: {
+    code: HttpStatus.NOT_FOUND,
+    data: ["supplier_id"] as const,
+  },
+  
+  // Allotment errors
+  [BackendErrors.ALLOTMENT_NOT_FOUND]: {
+    code: HttpStatus.NOT_FOUND,
+    data: ["allotment_id"] as const,
+  },
+  [BackendErrors.ALLOTMENT_REGISTRATION_FAILED]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: [] as const,
+  },
+  [BackendErrors.ALLOTMENT_UNDER_ANALYSIS]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: ["allotment_id"] as const,
+  },
+  [BackendErrors.CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: ["allotment_id"] as const,
+  },
+  
+  // File errors
+  [BackendErrors.FILE_NOT_FOUND]: {
+    code: HttpStatus.NOT_FOUND,
+    data: ["file_id"] as const,
+  },
+  [BackendErrors.FILE_CONVERSION_ERROR]: {
+    code: HttpStatus.INTERNAL_SERVER_ERROR,
+    data: [] as const,
+  },
+  
+  // Platform errors
+  [BackendErrors.PLATFORM_CONFIG_NOT_FOUND]: {
+    code: HttpStatus.NOT_FOUND,
+    data: [] as const,
+  },
+  
+  // Generic errors
+  [BackendErrors.MISSING_REQUIRED_FIELDS]: {
+    code: HttpStatus.BAD_REQUEST,
+    data: ["fields"] as const,
+  },
+  [BackendErrors.GENERIC_ERROR]: {
+    code: HttpStatus.INTERNAL_SERVER_ERROR,
+    data: [] as const,
   },
 } satisfies Record<BackendErrors, ErrorInfoProps>;
 

--- a/src/shared/exceptions/custom-http.exception.ts
+++ b/src/shared/exceptions/custom-http.exception.ts
@@ -1,6 +1,32 @@
 import { HttpException, HttpStatus } from "@nestjs/common";
 import { ResponseDtoV2 } from "../dtos/response.dto";
+import { BackendErrors, BackendErrorsInfo } from "../enums/errors";
 
+/**
+ * Custom HTTP V2 exception class for standardized error handling in the backend.
+ * 1.Criar o enum e informações do erro em shared/enums/errors.ts.
+ * @param error -Enum do erro, enum `BackendErrors`.
+ * @param data - O payload definido na tipagem: `BackendErrorsInfo`.
+ *
+ * @example
+ * throw new CustomHttpExceptionV2(BackendErrors.INVALID_TOKEN, { reason: 'Token expired' });
+ */
+export class CustomHttpExceptionV2<
+  T extends BackendErrors,
+> extends HttpException {
+  constructor(error: T, data: ErrorPayload<T>) {
+    const info = BackendErrorsInfo[error];
+    super(data, info.code);
+  }
+}
+
+type ErrorPayload<T extends BackendErrors> = {
+  [K in (typeof BackendErrorsInfo)[T]["data"][number]]: string | number;
+};
+
+/**
+ * @deprecated Use `CustomHttpExceptionV2` instead.
+ */
 export class CustomHttpException extends HttpException {
   constructor(
     errors: string | string[],

--- a/src/shared/helpers/structured-error.helper.ts
+++ b/src/shared/helpers/structured-error.helper.ts
@@ -12,32 +12,37 @@ export class StructuredErrorHelper {
    */
   static throw(errorKey: BackendErrors, data: Record<string, any> = {}): never {
     const errorInfo = BackendErrorsInfo[errorKey];
-    
-    console.log('StructuredErrorHelper.throw - errorKey:', errorKey);
-    console.log('StructuredErrorHelper.throw - data:', data);
-    console.log('StructuredErrorHelper.throw - errorInfo:', errorInfo);
-    
+
+    console.log("StructuredErrorHelper.throw - errorKey:", errorKey);
+    console.log("StructuredErrorHelper.throw - data:", data);
+    console.log("StructuredErrorHelper.throw - errorInfo:", errorInfo);
+
     if (!errorInfo) {
-      console.log('StructuredErrorHelper.throw - errorInfo not found, throwing generic error');
+      console.log(
+        "StructuredErrorHelper.throw - errorInfo not found, throwing generic error",
+      );
       throw new BadRequestException({
         error: BackendErrors.GENERIC_ERROR,
-        data: {}
+        data: {},
       });
     }
 
     const errorResponse = {
       error: errorKey,
-      data: data
+      data: data,
     };
 
-    console.log('StructuredErrorHelper.throw - errorResponse:', errorResponse);
-    console.log('StructuredErrorHelper.throw - throwing HttpException with code:', errorInfo.code);
+    console.log("StructuredErrorHelper.throw - errorResponse:", errorResponse);
+    console.log(
+      "StructuredErrorHelper.throw - throwing HttpException with code:",
+      errorInfo.code,
+    );
 
     // Criar uma exceção customizada que preserve a estrutura
     const customError = new HttpException(errorResponse, errorInfo.code);
     // Marcar como erro estruturado para que interceptadores possam identificar
     (customError as any).isStructuredError = true;
-    
+
     throw customError;
   }
 
@@ -54,7 +59,9 @@ export class StructuredErrorHelper {
    * @param proposalId ID da proposta
    */
   static throwProposalAlreadyDeleted(proposalId: string): never {
-    this.throw(BackendErrors.PROPOSAL_ALREADY_DELETED, { proposal_id: proposalId });
+    this.throw(BackendErrors.PROPOSAL_ALREADY_DELETED, {
+      proposal_id: proposalId,
+    });
   }
 
   /**
@@ -78,7 +85,9 @@ export class StructuredErrorHelper {
    * @param associationId ID da associação
    */
   static throwAssociationNotFound(associationId: string): never {
-    this.throw(BackendErrors.ASSOCIATION_NOT_FOUND, { association_id: associationId });
+    this.throw(BackendErrors.ASSOCIATION_NOT_FOUND, {
+      association_id: associationId,
+    });
   }
 
   /**
@@ -86,7 +95,9 @@ export class StructuredErrorHelper {
    * @param agreementId ID do convênio
    */
   static throwAgreementNotFound(agreementId: string): never {
-    this.throw(BackendErrors.AGREEMENT_NOT_FOUND, { agreement_id: agreementId });
+    this.throw(BackendErrors.AGREEMENT_NOT_FOUND, {
+      agreement_id: agreementId,
+    });
   }
 
   /**
@@ -110,7 +121,9 @@ export class StructuredErrorHelper {
    * @param allotmentId ID do lote
    */
   static throwAllotmentNotFound(allotmentId: string): never {
-    this.throw(BackendErrors.ALLOTMENT_NOT_FOUND, { allotment_id: allotmentId });
+    this.throw(BackendErrors.ALLOTMENT_NOT_FOUND, {
+      allotment_id: allotmentId,
+    });
   }
 
   /**
@@ -126,7 +139,9 @@ export class StructuredErrorHelper {
    * @param missingFields Array com os campos ausentes
    */
   static throwMissingRequiredFields(missingFields: string[]): never {
-    this.throw(BackendErrors.MISSING_REQUIRED_FIELDS, { fields: missingFields.join(", ") });
+    this.throw(BackendErrors.MISSING_REQUIRED_FIELDS, {
+      fields: missingFields.join(", "),
+    });
   }
 
   /**
@@ -134,7 +149,9 @@ export class StructuredErrorHelper {
    * @param allotmentId ID do lote
    */
   static throwCannotAcceptAllotmentInAnalysis(allotmentId: string): never {
-    this.throw(BackendErrors.CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS, { allotment_id: allotmentId });
+    this.throw(BackendErrors.CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS, {
+      allotment_id: allotmentId,
+    });
   }
 
   /**
@@ -160,7 +177,10 @@ export class StructuredErrorHelper {
    * @param fileType Tipo do arquivo
    */
   static throwBidDownloadFailed(bidId: string, fileType: string): never {
-    this.throw(BackendErrors.BID_DOWNLOAD_FAILED, { bid_id: bidId, file_type: fileType });
+    this.throw(BackendErrors.BID_DOWNLOAD_FAILED, {
+      bid_id: bidId,
+      file_type: fileType,
+    });
   }
 
   /**

--- a/src/shared/helpers/structured-error.helper.ts
+++ b/src/shared/helpers/structured-error.helper.ts
@@ -138,6 +138,94 @@ export class StructuredErrorHelper {
   }
 
   /**
+   * Lança erro de status de licitação inválido
+   * @param bidId ID da licitação
+   * @param status Status inválido
+   */
+  static throwBidInvalidStatus(bidId: string, status: string): never {
+    this.throw(BackendErrors.BID_INVALID_STATUS, { bid_id: bidId, status });
+  }
+
+  /**
+   * Lança erro de falha na geração de documento
+   * @param bidId ID da licitação
+   */
+  static throwBidDocumentGenerationFailed(bidId: string): never {
+    this.throw(BackendErrors.BID_DOCUMENT_GENERATION_FAILED, { bid_id: bidId });
+  }
+
+  /**
+   * Lança erro de falha no download
+   * @param bidId ID da licitação
+   * @param fileType Tipo do arquivo
+   */
+  static throwBidDownloadFailed(bidId: string, fileType: string): never {
+    this.throw(BackendErrors.BID_DOWNLOAD_FAILED, { bid_id: bidId, file_type: fileType });
+  }
+
+  /**
+   * Lança erro de acesso não autorizado à licitação
+   * @param bidId ID da licitação
+   */
+  static throwBidUnauthorizedAccess(bidId: string): never {
+    this.throw(BackendErrors.BID_UNAUTHORIZED_ACCESS, { bid_id: bidId });
+  }
+
+  /**
+   * Lança erro de falha no registro de usuário
+   */
+  static throwUserRegistrationFailed(): never {
+    this.throw(BackendErrors.USER_REGISTRATION_FAILED);
+  }
+
+  /**
+   * Lança erro de falha na atualização de usuário
+   * @param userId ID do usuário
+   */
+  static throwUserUpdateFailed(userId: string): never {
+    this.throw(BackendErrors.USER_UPDATE_FAILED, { user_id: userId });
+  }
+
+  /**
+   * Lança erro de email já existente
+   * @param email Email que já existe
+   */
+  static throwUserEmailAlreadyExists(email: string): never {
+    this.throw(BackendErrors.USER_EMAIL_ALREADY_EXISTS, { email });
+  }
+
+  /**
+   * Lança erro de credenciais inválidas
+   */
+  static throwUserInvalidCredentials(): never {
+    this.throw(BackendErrors.USER_INVALID_CREDENTIALS);
+  }
+
+  /**
+   * Lança erro de falha na atualização de senha
+   * @param userId ID do usuário
+   */
+  static throwUserPasswordUpdateFailed(userId: string): never {
+    this.throw(BackendErrors.USER_PASSWORD_UPDATE_FAILED, { user_id: userId });
+  }
+
+  /**
+   * Lança erro de código de verificação inválido
+   * @param code Código inválido
+   */
+  static throwUserVerificationCodeInvalid(code: string): never {
+    this.throw(BackendErrors.USER_VERIFICATION_CODE_INVALID, { code });
+  }
+
+  /**
+   * Lança erro de código de verificação expirado
+   * @param code Código expirado
+   */
+  static throwUserVerificationCodeExpired(code: string): never {
+    this.throw(BackendErrors.USER_VERIFICATION_CODE_EXPIRED, { code });
+  }
+
+  /**
    * Lança erro genérico
    */
   static throwGenericError(): never {

--- a/src/shared/helpers/structured-error.helper.ts
+++ b/src/shared/helpers/structured-error.helper.ts
@@ -1,0 +1,146 @@
+import { BadRequestException, HttpException } from "@nestjs/common";
+import { BackendErrors, BackendErrorsInfo } from "../enums/errors";
+
+/**
+ * Helper para lançar exceções estruturadas que o frontend pode mapear
+ */
+export class StructuredErrorHelper {
+  /**
+   * Lança uma exceção estruturada com base no enum BackendErrors
+   * @param errorKey Chave do erro do enum BackendErrors
+   * @param data Dados para interpolação (opcional)
+   */
+  static throw(errorKey: BackendErrors, data: Record<string, any> = {}): never {
+    const errorInfo = BackendErrorsInfo[errorKey];
+    
+    console.log('StructuredErrorHelper.throw - errorKey:', errorKey);
+    console.log('StructuredErrorHelper.throw - data:', data);
+    console.log('StructuredErrorHelper.throw - errorInfo:', errorInfo);
+    
+    if (!errorInfo) {
+      console.log('StructuredErrorHelper.throw - errorInfo not found, throwing generic error');
+      throw new BadRequestException({
+        error: BackendErrors.GENERIC_ERROR,
+        data: {}
+      });
+    }
+
+    const errorResponse = {
+      error: errorKey,
+      data: data
+    };
+
+    console.log('StructuredErrorHelper.throw - errorResponse:', errorResponse);
+    console.log('StructuredErrorHelper.throw - throwing HttpException with code:', errorInfo.code);
+
+    // Criar uma exceção customizada que preserve a estrutura
+    const customError = new HttpException(errorResponse, errorInfo.code);
+    // Marcar como erro estruturado para que interceptadores possam identificar
+    (customError as any).isStructuredError = true;
+    
+    throw customError;
+  }
+
+  /**
+   * Lança erro de proposta não encontrada
+   * @param proposalId ID da proposta
+   */
+  static throwProposalNotFound(proposalId: string): never {
+    this.throw(BackendErrors.PROPOSAL_NOT_FOUND, { proposal_id: proposalId });
+  }
+
+  /**
+   * Lança erro de proposta já deletada
+   * @param proposalId ID da proposta
+   */
+  static throwProposalAlreadyDeleted(proposalId: string): never {
+    this.throw(BackendErrors.PROPOSAL_ALREADY_DELETED, { proposal_id: proposalId });
+  }
+
+  /**
+   * Lança erro de licitação não encontrada
+   * @param bidId ID da licitação
+   */
+  static throwBidNotFound(bidId: string): never {
+    this.throw(BackendErrors.BID_NOT_FOUND, { bid_id: bidId });
+  }
+
+  /**
+   * Lança erro de licitação fechada
+   * @param bidId ID da licitação
+   */
+  static throwBidClosed(bidId: string): never {
+    this.throw(BackendErrors.BID_CLOSED, { bid_id: bidId });
+  }
+
+  /**
+   * Lança erro de associação não encontrada
+   * @param associationId ID da associação
+   */
+  static throwAssociationNotFound(associationId: string): never {
+    this.throw(BackendErrors.ASSOCIATION_NOT_FOUND, { association_id: associationId });
+  }
+
+  /**
+   * Lança erro de convênio não encontrado
+   * @param agreementId ID do convênio
+   */
+  static throwAgreementNotFound(agreementId: string): never {
+    this.throw(BackendErrors.AGREEMENT_NOT_FOUND, { agreement_id: agreementId });
+  }
+
+  /**
+   * Lança erro de usuário não encontrado
+   * @param userId ID do usuário
+   */
+  static throwUserNotFound(userId: string): never {
+    this.throw(BackendErrors.USER_NOT_FOUND, { user_id: userId });
+  }
+
+  /**
+   * Lança erro de fornecedor não encontrado
+   * @param supplierId ID do fornecedor
+   */
+  static throwSupplierNotFound(supplierId: string): never {
+    this.throw(BackendErrors.SUPPLIER_NOT_FOUND, { supplier_id: supplierId });
+  }
+
+  /**
+   * Lança erro de lote não encontrado
+   * @param allotmentId ID do lote
+   */
+  static throwAllotmentNotFound(allotmentId: string): never {
+    this.throw(BackendErrors.ALLOTMENT_NOT_FOUND, { allotment_id: allotmentId });
+  }
+
+  /**
+   * Lança erro de arquivo não encontrado
+   * @param fileId ID do arquivo
+   */
+  static throwFileNotFound(fileId: string): never {
+    this.throw(BackendErrors.FILE_NOT_FOUND, { file_id: fileId });
+  }
+
+  /**
+   * Lança erro de campos obrigatórios ausentes
+   * @param missingFields Array com os campos ausentes
+   */
+  static throwMissingRequiredFields(missingFields: string[]): never {
+    this.throw(BackendErrors.MISSING_REQUIRED_FIELDS, { fields: missingFields.join(", ") });
+  }
+
+  /**
+   * Lança erro quando não é possível aceitar lote em análise
+   * @param allotmentId ID do lote
+   */
+  static throwCannotAcceptAllotmentInAnalysis(allotmentId: string): never {
+    this.throw(BackendErrors.CANNOT_ACCEPT_ALLOTMENT_IN_ANALYSIS, { allotment_id: allotmentId });
+  }
+
+  /**
+   * Lança erro genérico
+   */
+  static throwGenericError(): never {
+    this.throw(BackendErrors.GENERIC_ERROR);
+  }
+}

--- a/tests/services/proposal.service.spec.ts
+++ b/tests/services/proposal.service.spec.ts
@@ -1,0 +1,811 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { faker } from '@faker-js/faker';
+import { ProposalService } from '../../src/modules/SOL/services/proposal.service';
+import { ProposalRepository } from '../../src/modules/SOL/repositories/proposal.repository';
+import { AllotmentRepository } from '../../src/modules/SOL/repositories/allotment.repository';
+import { AllotmentService } from '../../src/modules/SOL/services/allotment.service';
+import { BidRepository } from '../../src/modules/SOL/repositories/bid.repository';
+import { UserRepository } from '../../src/modules/SOL/repositories/user.repository';
+import { ContractService } from '../../src/modules/SOL/services/contract.service';
+import { NotificationService } from '../../src/modules/SOL/services/notification.service';
+import { BidService } from '../../src/modules/SOL/services/bid.service';
+import { ProposalRegisterDto } from '../../src/modules/SOL/dtos/proposal-register-request.dto';
+import { ProposalStatusEnum } from '../../src/modules/SOL/enums/proposal-status.enum';
+import { BidStatusEnum } from '../../src/modules/SOL/enums/bid-status.enum';
+import { BidTypeEnum } from '../../src/modules/SOL/enums/bid-type.enum';
+import { UserTypeEnum } from '../../src/modules/SOL/enums/user-type.enum';
+import { AllotmentStatusEnum } from '../../src/modules/SOL/enums/allotment-status.enum';
+import { ContractStatusEnum } from '../../src/modules/SOL/enums/contract-status.enum';
+import { ProposalModel } from '../../src/modules/SOL/models/proposal.model';
+import { BidModel } from '../../src/modules/SOL/models/bid.model';
+import { UserModel } from '../../src/modules/SOL/models/user.model';
+import { AllotmentModel } from '../../src/modules/SOL/models/allotment.model';
+
+describe('ProposalService', () => {
+  let service: ProposalService;
+  let proposalRepository: jest.Mocked<ProposalRepository>;
+  let allotmentRepository: jest.Mocked<AllotmentRepository>;
+  let allotmentService: jest.Mocked<AllotmentService>;
+  let bidRepository: jest.Mocked<BidRepository>;
+  let userRepository: jest.Mocked<UserRepository>;
+  let contractService: jest.Mocked<ContractService>;
+  let notificationService: jest.Mocked<NotificationService>;
+  let bidService: jest.Mocked<BidService>;
+
+  // Mock data factories
+  const createMockUser = (overrides: Partial<UserModel> = {}): UserModel => ({
+    _id: faker.database.mongodbObjectId(),
+    name: faker.person.fullName(),
+    email: faker.internet.email(),
+    type: UserTypeEnum.fornecedor,
+    supplier: {
+      _id: faker.database.mongodbObjectId(),
+      name: faker.company.name(),
+    },
+    ...overrides,
+  } as UserModel);
+
+  const createMockBid = (overrides: Partial<BidModel> = {}): BidModel => ({
+    _id: faker.database.mongodbObjectId(),
+    id: faker.database.mongodbObjectId(),
+    bid_type: BidTypeEnum.globalPrice,
+    status: BidStatusEnum.open,
+    ...overrides,
+  } as BidModel);
+
+  const createMockAllotment = (overrides: Partial<AllotmentModel> = {}): AllotmentModel => ({
+    _id: faker.database.mongodbObjectId(),
+    id: faker.database.mongodbObjectId(),
+    proposals: [],
+    status: AllotmentStatusEnum.rascunho,
+    ...overrides,
+  } as AllotmentModel);
+
+  const createMockProposal = (overrides: Partial<ProposalModel> = {}): ProposalModel => ({
+    _id: faker.database.mongodbObjectId(),
+    id: faker.database.mongodbObjectId(),
+    total_value: faker.commerce.price(),
+    status: ProposalStatusEnum.aguardando1,
+    proposalWin: false,
+    deleted: false,
+    supplier_accept: false,
+    association_accept: false,
+    reviewer_accept: false,
+    proposedBy: createMockUser(),
+    bid: createMockBid(),
+    allotment: [createMockAllotment()],
+    freight: 0,
+    ...overrides,
+  } as ProposalModel);
+
+  beforeEach(async () => {
+    const mockProposalRepository = {
+      register: jest.fn(),
+      listNonDeleted: jest.fn(),
+      getById: jest.fn(),
+      listByBid: jest.fn(),
+      listByUser: jest.fn(),
+      updateAcceptSupplier: jest.fn(),
+      updateAcceptAssociation: jest.fn(),
+      updateAcceptReviewer: jest.fn(),
+      updateStatus: jest.fn(),
+      addItem: jest.fn(),
+      removeItem: jest.fn(),
+      deleteById: jest.fn(),
+      updateProposedWin: jest.fn(),
+      updateListProposedWin: jest.fn(),
+      refusedProposal: jest.fn(),
+      acceptForFornecedorProposal: jest.fn(),
+      acceptForRevisorProposal: jest.fn(),
+      getProposalWin: jest.fn(),
+      listByBidsWaiting: jest.fn(),
+      updateValues: jest.fn(),
+    };
+
+    const mockAllotmentRepository = {
+      listById: jest.fn(),
+      listByIds: jest.fn(),
+      addProposal: jest.fn(),
+      register: jest.fn(),
+      updateStatusByIds: jest.fn(),
+    };
+
+    const mockAllotmentService = {
+      updateStatus: jest.fn(),
+    };
+
+    const mockBidRepository = {
+      getById: jest.fn(),
+      changeStatus: jest.fn(),
+    };
+
+    const mockUserRepository = {
+      getById: jest.fn(),
+    };
+
+    const mockContractService = {
+      register: jest.fn(),
+    };
+
+    const mockNotificationService = {
+      send: jest.fn(),
+    };
+
+    const mockBidService = {
+      getById: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProposalService,
+        { provide: ProposalRepository, useValue: mockProposalRepository },
+        { provide: AllotmentRepository, useValue: mockAllotmentRepository },
+        { provide: AllotmentService, useValue: mockAllotmentService },
+        { provide: BidRepository, useValue: mockBidRepository },
+        { provide: UserRepository, useValue: mockUserRepository },
+        { provide: ContractService, useValue: mockContractService },
+        { provide: NotificationService, useValue: mockNotificationService },
+        { provide: BidService, useValue: mockBidService },
+      ],
+    }).compile();
+
+    service = module.get<ProposalService>(ProposalService);
+    proposalRepository = module.get(ProposalRepository);
+    allotmentRepository = module.get(AllotmentRepository);
+    allotmentService = module.get(AllotmentService);
+    bidRepository = module.get(BidRepository);
+    userRepository = module.get(UserRepository);
+    contractService = module.get(ContractService);
+    notificationService = module.get(NotificationService);
+    bidService = module.get(BidService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('register', () => {
+    it('should register a new proposal successfully when no proposals exist', async () => {
+      const proposedById = faker.database.mongodbObjectId();
+      const mockUser = createMockUser();
+      const mockBid = createMockBid({ status: BidStatusEnum.open, bid_type: BidTypeEnum.individualPrice });
+      const mockAllotment = createMockAllotment();
+      const mockProposal = createMockProposal();
+      
+      const allotmentId = faker.database.mongodbObjectId();
+      const dto: ProposalRegisterDto = {
+        total_value: faker.number.float({ min: 100, max: 1000 }).toString(),
+        licitacaoId: faker.database.mongodbObjectId(),
+        allotmentIds: [allotmentId],
+        item_list: [],
+        deleted: false,
+        status: ProposalStatusEnum.aguardando1,
+        proposedById,
+        file: '',
+        association_accept: false,
+        supplier_accept: false,
+        proposalWin: false,
+        freight: 0,
+        proposedBy: undefined,
+        bid: undefined,
+        allotment: undefined,
+      };
+
+      userRepository.getById.mockResolvedValue(mockUser);
+      bidRepository.getById.mockResolvedValue(mockBid);
+      allotmentRepository.listById.mockResolvedValue(mockAllotment);
+      proposalRepository.listByBid.mockResolvedValue([]);
+      proposalRepository.register.mockResolvedValue(mockProposal);
+      allotmentRepository.addProposal.mockResolvedValue(mockAllotment);
+
+      const result = await service.register(proposedById, dto);
+
+      expect(result).toEqual(mockProposal);
+      expect(proposalRepository.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          proposalWin: true,
+          status: ProposalStatusEnum.aguardando1,
+          proposedBy: mockUser,
+          bid: mockBid,
+          allotment: [mockAllotment],
+        })
+      );
+      expect(allotmentRepository.addProposal).toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when bid is closed', async () => {
+      const proposedById = faker.database.mongodbObjectId();
+      const mockUser = createMockUser();
+      const mockBid = createMockBid({ status: BidStatusEnum.canceled });
+      
+      const allotmentId = faker.database.mongodbObjectId();
+      const dto: ProposalRegisterDto = {
+        total_value: faker.number.float({ min: 100, max: 1000 }).toString(),
+        item_list: [faker.lorem.word()],
+        licitacaoId: faker.database.mongodbObjectId(),
+        proposedById: proposedById,
+        allotmentIds: [allotmentId],
+        proposalWin: false,
+        freight: 0,
+        proposedBy: undefined,
+        bid: undefined,
+        allotment: undefined,
+        deleted: false,
+        status: ProposalStatusEnum.aguardando1,
+        file: faker.lorem.word(),
+        association_accept: false,
+        supplier_accept: false,
+      };
+
+      userRepository.getById.mockResolvedValue(mockUser);
+      bidRepository.getById.mockResolvedValue(mockBid);
+
+      await expect(service.register(proposedById, dto)).rejects.toThrow(
+        new BadRequestException('Não é possivel cadastrar proposta para licitação fechada!')
+      );
+    });
+  });
+
+  describe('list', () => {
+    it('should return all non-deleted proposals', async () => {
+      const mockProposals = [createMockProposal(), createMockProposal()];
+      proposalRepository.listNonDeleted.mockResolvedValue(mockProposals);
+
+      const result = await service.list();
+
+      expect(result).toEqual(mockProposals);
+      expect(proposalRepository.listNonDeleted).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateAcceptfromSupplier', () => {
+    it('should update supplier acceptance successfully', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const mockProposal = createMockProposal();
+      const updatedProposal = createMockProposal({ supplier_accept: true });
+      const dto = { supplier_accept: true };
+
+      proposalRepository.getById.mockResolvedValue(mockProposal);
+      proposalRepository.updateAcceptSupplier.mockResolvedValue(updatedProposal);
+
+      const result = await service.updateAcceptfromSupplier(proposalId, dto);
+
+      expect(result).toEqual(updatedProposal);
+      expect(proposalRepository.updateAcceptSupplier).toHaveBeenCalledWith(proposalId, dto);
+    });
+
+    it('should throw BadRequestException when proposal not found', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const dto = { supplier_accept: true };
+
+      proposalRepository.getById.mockResolvedValue(null);
+
+      await expect(service.updateAcceptfromSupplier(proposalId, dto)).rejects.toThrow(
+        new BadRequestException('Proposta não encontrada!')
+      );
+    });
+  });
+
+  describe('getById', () => {
+    it('should return proposal by id successfully', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const mockProposal = createMockProposal();
+
+      proposalRepository.getById.mockResolvedValue(mockProposal);
+
+      const result = await service.getById(proposalId);
+
+      expect(result).toEqual(mockProposal);
+      expect(proposalRepository.getById).toHaveBeenCalledWith(proposalId);
+    });
+
+    it('should throw BadRequestException when proposal not found', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+
+      proposalRepository.getById.mockResolvedValue(null);
+
+      await expect(service.getById(proposalId)).rejects.toThrow(
+        new BadRequestException('Proposta não encontrada!')
+      );
+    });
+
+    it('should throw BadRequestException when proposal is deleted', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const deletedProposal = createMockProposal({ deleted: true });
+
+      proposalRepository.getById.mockResolvedValue(deletedProposal);
+
+      await expect(service.getById(proposalId)).rejects.toThrow(
+        new BadRequestException('Esse contrato já foi deletado!')
+      );
+    });
+  });
+
+  describe('deleteById', () => {
+    it('should delete proposal by id', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+
+      proposalRepository.deleteById.mockResolvedValue(undefined);
+
+      const result = await service.deleteById(proposalId);
+
+      expect(proposalRepository.deleteById).toHaveBeenCalledWith(proposalId);
+    });
+  });
+
+  describe('listByBid', () => {
+    it('should return proposals by bid id', async () => {
+      const bidId = faker.database.mongodbObjectId();
+      const mockProposals = [createMockProposal()];
+      const mockBid = createMockBid();
+      const mockResponse = { proposals: mockProposals, bid: mockBid };
+
+      proposalRepository.listByBid.mockResolvedValue(mockProposals);
+      bidService.getById.mockResolvedValue(mockBid);
+
+      const result = await service.listByBid(bidId);
+
+      expect(proposalRepository.listByBid).toHaveBeenCalledWith(bidId);
+      expect(bidService.getById).toHaveBeenCalledWith(bidId);
+    });
+  });
+
+  describe('getProposalAcceptByBid', () => {
+    it('should return accepted winning proposal', async () => {
+      const bidId = faker.database.mongodbObjectId();
+      const winningProposal = createMockProposal({ 
+        proposalWin: true 
+      }) as any;
+      winningProposal.acceptedFornecedor = true;
+      const mockProposals = [winningProposal, createMockProposal()];
+
+      proposalRepository.listByBid.mockResolvedValue(mockProposals);
+
+      const result = await service.getProposalAcceptByBid(bidId);
+
+      expect(result).toEqual(winningProposal);
+    });
+
+    it('should return undefined when no accepted winning proposal exists', async () => {
+      const bidId = faker.database.mongodbObjectId();
+      const mockProposals = [createMockProposal()];
+
+      proposalRepository.listByBid.mockResolvedValue(mockProposals);
+
+      const result = await service.getProposalAcceptByBid(bidId);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('updateAcceptAssociation', () => {
+    it('should update association acceptance successfully', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const mockProposal = createMockProposal();
+      const updatedProposal = createMockProposal({ association_accept: true });
+      const dto = { association_accept: true };
+
+      proposalRepository.getById.mockResolvedValue(mockProposal);
+      proposalRepository.updateAcceptAssociation.mockResolvedValue(updatedProposal);
+
+      const result = await service.updateAcceptAssociation(proposalId, dto);
+
+      expect(result).toEqual(updatedProposal);
+      expect(proposalRepository.updateAcceptAssociation).toHaveBeenCalledWith(proposalId, dto);
+    });
+
+    it('should throw BadRequestException when proposal not found', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const dto = { association_accept: true };
+
+      proposalRepository.getById.mockResolvedValue(null);
+
+      await expect(service.updateAcceptAssociation(proposalId, dto)).rejects.toThrow(
+        new BadRequestException('Proposta não encontrada!')
+      );
+    });
+
+    it('should update status when both supplier and association accept', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const mockProposal = createMockProposal();
+      const updatedProposal = createMockProposal({ 
+        supplier_accept: true, 
+        association_accept: true 
+      });
+      const dto = { association_accept: true };
+
+      proposalRepository.getById.mockResolvedValue(mockProposal);
+      proposalRepository.updateAcceptAssociation.mockResolvedValue(updatedProposal);
+      proposalRepository.updateStatus.mockResolvedValue(updatedProposal);
+
+      const result = await service.updateAcceptAssociation(proposalId, dto);
+
+      expect(proposalRepository.updateStatus).toHaveBeenCalledWith(
+        proposalId,
+        { status: ProposalStatusEnum.aceitoAssociacao }
+      );
+    });
+  });
+
+  describe('updateAcceptReviewer', () => {
+    it('should update reviewer acceptance successfully', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const userId = faker.database.mongodbObjectId();
+      const mockProposal = createMockProposal({
+        association_accept: true,
+        reviewer_accept: true,
+      });
+      const dto = { reviewer_accept: true, acceptedRevisorAt: new Date().toISOString() };
+
+      proposalRepository.getById.mockResolvedValue(mockProposal);
+      proposalRepository.updateAcceptReviewer.mockResolvedValue(mockProposal);
+      allotmentService.updateStatus.mockResolvedValue(undefined);
+
+      jest.spyOn(service, 'acceptProposal').mockResolvedValue(mockProposal);
+
+      const result = await service.updateAcceptReviewer(proposalId, dto, userId);
+
+      expect(proposalRepository.updateAcceptReviewer).toHaveBeenCalledWith(proposalId, dto);
+      expect(allotmentService.updateStatus).toHaveBeenCalledWith(
+        mockProposal.allotment[0].id,
+        AllotmentStatusEnum.adjudicado
+      );
+      expect(service.acceptProposal).toHaveBeenCalledWith(mockProposal._id.toString(), userId);
+    });
+
+    it('should update allotment status to failed when reviewer rejects', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const userId = faker.database.mongodbObjectId();
+      const mockProposal = createMockProposal();
+      const dto = { reviewer_accept: false, acceptedRevisorAt: new Date().toISOString() };
+
+      proposalRepository.getById.mockResolvedValue(mockProposal);
+      proposalRepository.updateAcceptReviewer.mockResolvedValue(mockProposal);
+      allotmentService.updateStatus.mockResolvedValue(undefined);
+
+      const result = await service.updateAcceptReviewer(proposalId, dto, userId);
+
+      expect(allotmentService.updateStatus).toHaveBeenCalledWith(
+        mockProposal.allotment[0].id,
+        AllotmentStatusEnum.fracassado
+      );
+    });
+  });
+
+  describe('refusedProposal', () => {
+    it('should refuse proposal successfully by association', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const refusedById = faker.database.mongodbObjectId();
+      const mockUser = createMockUser({ type: UserTypeEnum.associacao });
+      const mockProposal = createMockProposal();
+      const dto = { 
+        refusedBecaused: 'Test reason',
+        refusedAt: new Date(),
+        data: {} as any,
+        status: ProposalStatusEnum.recusadaAssociacao,
+        refusedBy: mockUser
+      };
+      const refusedProposal = createMockProposal({ 
+        status: ProposalStatusEnum.recusadaAssociacao 
+      });
+
+      userRepository.getById.mockResolvedValue(mockUser);
+      proposalRepository.getById.mockResolvedValue(mockProposal);
+      proposalRepository.listByBid.mockResolvedValue([mockProposal]);
+      proposalRepository.updateProposedWin.mockResolvedValue(mockProposal);
+      proposalRepository.refusedProposal.mockResolvedValue(refusedProposal);
+      allotmentService.updateStatus.mockResolvedValue(undefined);
+
+      const result = await service.refusedProposal(proposalId, refusedById, dto);
+
+      expect(result).toEqual(refusedProposal);
+      expect(proposalRepository.refusedProposal).toHaveBeenCalledWith(
+        proposalId,
+        expect.objectContaining({
+          refusedBy: mockUser,
+          status: ProposalStatusEnum.recusadaAssociacao,
+          refusedAt: expect.any(Date),
+        })
+      );
+    });
+
+    it('should refuse proposal successfully by reviewer', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const refusedById = faker.database.mongodbObjectId();
+      const mockUser = createMockUser({ type: UserTypeEnum.administrador });
+      const mockProposal = createMockProposal();
+      const dto = { 
+        refusedBecaused: 'Test reason',
+        refusedAt: new Date(),
+        data: {} as any,
+        status: ProposalStatusEnum.recusadaRevisor,
+        refusedBy: mockUser
+      };
+      const refusedProposal = createMockProposal({ 
+        status: ProposalStatusEnum.recusadaRevisor 
+      });
+
+      userRepository.getById.mockResolvedValue(mockUser);
+      proposalRepository.getById.mockResolvedValue(mockProposal);
+      proposalRepository.listByBid.mockResolvedValue([mockProposal]);
+      proposalRepository.updateProposedWin.mockResolvedValue(mockProposal);
+      proposalRepository.refusedProposal.mockResolvedValue(refusedProposal);
+      allotmentService.updateStatus.mockResolvedValue(undefined);
+
+      const result = await service.refusedProposal(proposalId, refusedById, dto);
+
+      expect(result).toEqual(refusedProposal);
+      expect(proposalRepository.refusedProposal).toHaveBeenCalledWith(
+        proposalId,
+        expect.objectContaining({
+          refusedBy: mockUser,
+          status: ProposalStatusEnum.recusadaRevisor,
+          refusedAt: expect.any(Date),
+        })
+      );
+    });
+  });
+
+  describe('acceptProposal', () => {
+    it('should accept proposal by association successfully', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const acceptById = faker.database.mongodbObjectId();
+      const mockUser = createMockUser({ type: UserTypeEnum.associacao });
+      
+      // Create a proper mock proposal structure
+      const mockProposalInAllotment = createMockProposal({ _id: proposalId });
+      const mockAllotment = createMockAllotment({
+        proposals: [{ proposal: mockProposalInAllotment, proposalWin: false }]
+      });
+      const mockProposal = createMockProposal({ 
+        _id: proposalId,
+        allotment: [mockAllotment] 
+      });
+      
+      const acceptedProposal = createMockProposal({ 
+        status: ProposalStatusEnum.aceitoAssociacao 
+      });
+
+      userRepository.getById.mockResolvedValue(mockUser);
+      proposalRepository.getById.mockResolvedValue(mockProposal);
+      proposalRepository.updateAcceptAssociation.mockResolvedValue(mockProposal);
+      proposalRepository.acceptForFornecedorProposal.mockResolvedValue(acceptedProposal);
+      proposalRepository.updateStatus.mockResolvedValue(acceptedProposal);
+      allotmentService.updateStatus.mockResolvedValue(undefined);
+      allotmentRepository.register.mockResolvedValue(mockAllotment);
+
+      const result = await service.acceptProposal(proposalId, acceptById);
+
+      expect(result).toEqual(acceptedProposal);
+      expect(proposalRepository.updateAcceptAssociation).toHaveBeenCalled();
+      expect(allotmentService.updateStatus).toHaveBeenCalledWith(
+        mockAllotment._id.toString(),
+        AllotmentStatusEnum.adjudicado
+      );
+    });
+
+    it('should accept proposal by reviewer and create contract', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const acceptById = faker.database.mongodbObjectId();
+      const mockUser = createMockUser({ type: UserTypeEnum.administrador });
+      
+      // Create a proper mock proposal structure
+      const mockProposalInAllotment = createMockProposal({ _id: proposalId });
+      const mockAllotment = createMockAllotment({
+        proposals: [{ proposal: mockProposalInAllotment, proposalWin: false }]
+      });
+      const mockProposal = createMockProposal({ 
+        _id: proposalId,
+        allotment: [mockAllotment] 
+      });
+      
+      const mockBid = createMockBid();
+      const acceptedProposal = createMockProposal({ 
+        status: ProposalStatusEnum.aceitoRevisor 
+      });
+
+      userRepository.getById.mockResolvedValue(mockUser);
+      proposalRepository.getById.mockResolvedValue(mockProposal);
+      bidRepository.getById.mockResolvedValue(mockBid);
+      bidRepository.changeStatus.mockResolvedValue(mockBid);
+      allotmentRepository.updateStatusByIds.mockResolvedValue(undefined);
+      allotmentRepository.register.mockResolvedValue(mockAllotment);
+      proposalRepository.acceptForRevisorProposal.mockResolvedValue(acceptedProposal);
+      contractService.register.mockResolvedValue({} as any);
+
+      const result = await service.acceptProposal(proposalId, acceptById);
+
+      expect(result).toEqual(acceptedProposal);
+      expect(contractService.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: ContractStatusEnum.aguardando_assinaturas,
+          proposal_id: [mockProposal],
+        })
+      );
+      expect(bidRepository.changeStatus).toHaveBeenCalledWith(
+        expect.any(String),
+        { status: BidStatusEnum.completed }
+      );
+    });
+
+    it('should throw BadRequestException when allotment is under analysis', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const acceptById = faker.database.mongodbObjectId();
+      const mockUser = createMockUser({ type: UserTypeEnum.associacao });
+      const mockAllotment = createMockAllotment({ status: AllotmentStatusEnum.emAnalise });
+      const mockProposal = createMockProposal({ allotment: [mockAllotment] });
+
+      userRepository.getById.mockResolvedValue(mockUser);
+      proposalRepository.getById.mockResolvedValue(mockProposal);
+
+      await expect(service.acceptProposal(proposalId, acceptById)).rejects.toThrow(
+        new BadRequestException('Não é possível recusar propostas enquanto o lote está em análise.')
+      );
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('should update proposal status successfully', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const mockProposal = createMockProposal();
+      const updatedProposal = createMockProposal({ 
+        status: ProposalStatusEnum.aceitoAssociacao 
+      });
+      const dto = { status: ProposalStatusEnum.aceitoAssociacao };
+
+      proposalRepository.getById.mockResolvedValue(mockProposal);
+      proposalRepository.updateStatus.mockResolvedValue(updatedProposal);
+
+      const result = await service.updateStatus(proposalId, dto);
+
+      expect(result).toEqual(updatedProposal);
+      expect(proposalRepository.updateStatus).toHaveBeenCalledWith(proposalId, dto);
+    });
+
+    it('should throw BadRequestException when proposal not found', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const dto = { status: ProposalStatusEnum.aceitoAssociacao };
+
+      proposalRepository.getById.mockResolvedValue(null);
+
+      await expect(service.updateStatus(proposalId, dto)).rejects.toThrow(
+        new BadRequestException('Proposta não encontrada!')
+      );
+    });
+  });
+
+  describe('getByUserInBid', () => {
+    it('should return true when user has proposal in allotment', async () => {
+      const proposedById = faker.database.mongodbObjectId();
+      const allotmentId = faker.database.mongodbObjectId();
+      const mockAllotment = createMockAllotment({ _id: allotmentId });
+      const mockProposal = createMockProposal({ allotment: [mockAllotment] });
+
+      proposalRepository.listByUser.mockResolvedValue([mockProposal]);
+
+      const result = await service.getByUserInBid(proposedById, allotmentId);
+
+      expect(result).toBe(true);
+      expect(proposalRepository.listByUser).toHaveBeenCalledWith(proposedById);
+    });
+
+    it('should return false when user has no proposal in allotment', async () => {
+      const proposedById = faker.database.mongodbObjectId();
+      const allotmentId = faker.database.mongodbObjectId();
+
+      proposalRepository.listByUser.mockResolvedValue([]);
+
+      const result = await service.getByUserInBid(proposedById, allotmentId);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('addItem', () => {
+    it('should add item to proposal successfully', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const mockProposal = createMockProposal();
+      const dto = { item_list: 'new-item' };
+
+      proposalRepository.getById.mockResolvedValue(mockProposal);
+      proposalRepository.addItem.mockResolvedValue(mockProposal);
+
+      const result = await service.addItem(proposalId, dto);
+
+      expect(result).toEqual(mockProposal);
+      expect(proposalRepository.addItem).toHaveBeenCalledWith(proposalId, dto);
+    });
+
+    it('should throw BadRequestException when proposal not found', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const dto = { item_list: 'new-item' };
+
+      proposalRepository.getById.mockResolvedValue(null);
+
+      await expect(service.addItem(proposalId, dto)).rejects.toThrow(
+        new BadRequestException('Proposta não encontrada!')
+      );
+    });
+  });
+
+  describe('removeItem', () => {
+    it('should remove item from proposal successfully', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const mockProposal = createMockProposal();
+      const dto = { item_list: 'item-to-remove' };
+
+      proposalRepository.getById.mockResolvedValue(mockProposal);
+      proposalRepository.removeItem.mockResolvedValue(mockProposal);
+
+      const result = await service.removeItem(proposalId, dto);
+
+      expect(result).toEqual(mockProposal);
+      expect(proposalRepository.removeItem).toHaveBeenCalledWith(proposalId, dto);
+    });
+
+    it('should throw BadRequestException when proposal not found', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const dto = { item_list: 'item-to-remove' };
+
+      proposalRepository.getById.mockResolvedValue(null);
+
+      await expect(service.removeItem(proposalId, dto)).rejects.toThrow(
+        new BadRequestException('Proposta não encontrada!')
+      );
+    });
+  });
+
+  describe('updateValues', () => {
+    it('should update proposal values successfully for globalPrice bid', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const dto = { total_value: '2000', freight: 100 };
+      const mockBid = createMockBid({ bid_type: BidTypeEnum.globalPrice });
+      const updatedProposal = createMockProposal({ 
+        total_value: '2000', 
+        freight: 100, 
+        bid: mockBid 
+      });
+      const mockAllotments = [createMockAllotment()];
+      const proposalList = [updatedProposal];
+
+      proposalRepository.updateValues.mockResolvedValue(updatedProposal);
+      proposalRepository.listByBid.mockResolvedValue(proposalList);
+      allotmentRepository.listByIds.mockResolvedValue(mockAllotments);
+      proposalRepository.updateListProposedWin.mockResolvedValue(undefined);
+      allotmentRepository.addProposal.mockResolvedValue(mockAllotments[0]);
+
+      const result = await service.updateValues(proposalId, dto);
+
+      expect(result).toEqual(updatedProposal);
+      expect(proposalRepository.updateValues).toHaveBeenCalledWith(proposalId, dto);
+      expect(proposalRepository.updateListProposedWin).toHaveBeenCalled();
+    });
+
+    it('should update proposal values successfully for non-globalPrice bid', async () => {
+      const proposalId = faker.database.mongodbObjectId();
+      const dto = { total_value: '2000', freight: 100 };
+      const mockBid = createMockBid({ bid_type: BidTypeEnum.individualPrice });
+      const updatedProposal = createMockProposal({ 
+        total_value: '2000', 
+        freight: 100, 
+        bid: mockBid 
+      });
+      const mockAllotments = [createMockAllotment({
+        proposals: [{ proposal: updatedProposal, proposalWin: false }]
+      })];
+      const proposalList = [updatedProposal];
+
+      proposalRepository.updateValues.mockResolvedValue(updatedProposal);
+      proposalRepository.listByBid.mockResolvedValue(proposalList);
+      allotmentRepository.listByIds.mockResolvedValue(mockAllotments);
+      proposalRepository.updateListProposedWin.mockResolvedValue(undefined);
+      allotmentRepository.addProposal.mockResolvedValue(mockAllotments[0]);
+
+      const result = await service.updateValues(proposalId, dto);
+
+      expect(result).toEqual(updatedProposal);
+      expect(proposalRepository.updateValues).toHaveBeenCalledWith(proposalId, dto);
+    });
+  });
+});

--- a/tests/services/user.service.spec.ts
+++ b/tests/services/user.service.spec.ts
@@ -1,11 +1,11 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { UserService } from "./user.service";
-import { UserRepository } from "../repositories/user.repository";
-import { SupplierService } from "../services/supplier.service";
-import { UserRegisterRequestDto } from "../dtos/user-register-request.dto";
-import { UserTypeEnum } from "../enums/user-type.enum";
-import { AssociationService } from "./association.service";
-import { VerificationService } from "./verification.service";
+import { UserService } from "../../src/modules/SOL/services/user.service";
+import { UserRepository } from "../../src/modules/SOL/repositories/user.repository";
+import { SupplierService } from "../../src/modules/SOL/services/supplier.service";
+import { UserRegisterRequestDto } from "../../src/modules/SOL/dtos/user-register-request.dto";
+import { UserTypeEnum } from "../../src/modules/SOL/enums/user-type.enum";
+import { AssociationService } from "../../src/modules/SOL/services/association.service";
+import { VerificationService } from "../../src/modules/SOL/services/verification.service";
 import { BadRequestException } from "@nestjs/common";
 
 // Mocks


### PR DESCRIPTION
Correção: Falha na aceitação de propostas

### Problema Identificado
O sistema estava falhando ao aceitar propostas devido a dois problemas principais:

1. **Erro de referência de objetos**: O código assumia que `proposal.bid` sempre seria um objeto com propriedade `.id`, mas dependendo do contexto de população do MongoDB/Mongoose, pode ser uma string ou objeto com `_id`
2. **Falta de validação de status**: Não havia verificação se lotes estavam em análise antes de aceitar/recusar propostas

### Soluções Implementadas

#### Tratamento robusto de referências
- Implementado verificação de tipo para `proposal.bid` e `proposal.proposedBy.supplier`
- Suporte para diferentes formatos: string, objeto com `_id` ou `id`
- Evita erros "Cannot read property 'id' of undefined"

#### Nova validação de regra de negócio
- Adicionada verificação de status `AllotmentStatusEnum.emAnalise` nos lotes
- Impede aceitar/recusar propostas quando lotes estão em análise
- Retorna erro claro: "Não é possível aceitar propostas enquanto o lote está em análise"

### Arquivos Alterados
- [backend/src/modules/SOL/services/proposal.service.ts](cci:7://file:///c:/Users/trabalho/apps/staging/219-investigar-falha-aceitacao-propostas/backend/src/modules/SOL/services/proposal.service.ts:0:0-0:0)
- Adicionadas validações nos métodos de aceitar e recusar propostas